### PR TITLE
Валидация эпизодов 300-399

### DIFF
--- a/validation/episodes/0300-0399/0300.yaml
+++ b/validation/episodes/0300-0399/0300.yaml
@@ -1,0 +1,218 @@
+episode: 300
+status: clean
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [PetrDidenko, Marin_k_a]
+  total_duration_sec: 8774
+  notes: |
+    Юбилейный 300-й выпуск (фактически 301-й если считать с нуля).
+    Пётр Диденко присутствовал физически в студии ("вторая напервильская студия").
+    Марина участвовала удалённо.
+    Представление участников: 85-98 сек.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "PetrDidenko"
+    total_duration_sec: 775
+    replies_count: 228
+    pattern: consecutive
+    analysis:
+      is_error: false
+      identified_as: "petr_didenko"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        95s: "Петя, скажи здрасте гостям" (Umputun)
+        97s: "Всем привет. Привет из второй напервильской." (PetrDidenko)
+        Пётр уже в справочнике как известный постоянный гость (148 выпусков).
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 408
+    replies_count: 153
+    pattern: consecutive
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        116s: "Марусенька, ты с нами?" (Umputun)
+        118s: "Я с вами, я никогда не сидела на твоём диване..." (Marin_k_a)
+        Марина (Marin_k_a) уже в справочнике как бывшая ведущая.
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 4
+    replies_count: 3
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: |
+        Это явно не Эльдар Муртазин - он не участвовал в выпуске 300.
+        Короткие фразы ("Вот я пишу", "Ну а что тебе пуша?", "Я даже понимаю...")
+        Все в контексте диалога Umputun с другими ведущими.
+        Скорее всего это ошибочно атрибутированные реплики одного из ведущих.
+      identified_as: null
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.6
+          reason: |
+            4201s: "Вот я пишу" - следует сразу за репликой Umputun "это самый правильный ответ",
+            затем Bobuk говорит "пока Женя там пишет стоп" - подтверждает что это Umputun.
+        - person_id: "gray"
+          confidence: 0.3
+          reason: Мог быть Gray, судя по тону некоторых реплик.
+      voice_task:
+        needed: false
+        reason: Слишком короткие фрагменты для voice comparison.
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика: 6121s "Итак, я пишу стоп."
+        Сразу после Umputun "Смотрю, дробной части нет" и до Bobuk "Жень, ты в следующий раз проси делить."
+        Контекст явно указывает что это Umputun пишет "стоп" в чат для розыгрыша.
+      identified_as: "umputun"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Bobuk обращается "Жень" сразу после этой реплики, подтверждая что говорил Umputun.
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_06"
+    total_duration_sec: 3
+    replies_count: 6
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: |
+        Все реплики очень короткие (0.1-1.7 сек): "Да", "Да", "Это от грозы", "Ага", "Уходи дважды", "Пока".
+        Разбросаны по всему выпуску - типичные ошибки распознавания.
+        Скорее всего это подхватки других участников, неверно атрибутированные.
+      identified_as: null
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.4
+          reason: 4295s "Это от грозы" - следует за репликой Umputun, мог быть комментарий Gray.
+        - person_id: "petr_didenko"
+          confidence: 0.3
+          reason: Пётр был в студии, некоторые подхватки могли быть его.
+        - person_id: "marin_k_a"
+          confidence: 0.2
+          reason: 8774s "Пока" - в самом конце, могла быть Марина.
+      voice_task:
+        needed: false
+        reason: Слишком короткие фрагменты (<2 сек) для достоверного voice comparison.
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика 6971s: "Мы можем просто разыграть."
+        Находится между репликами Marin_k_a (6970s и 6973s).
+        Lavale не участвовала в выпуске 300.
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Реплика окружена репликами Marin_k_a, продолжает её мысль о розыгрыше.
+        Скорее всего ошибка транскрипции - это Марина.
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 6
+    replies_count: 1
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика 8153s: "Т-А-Р-А-К-И-Т-И-К-О-С" - побуквенное произношение.
+        Контекст: Umputun 8149s говорит "Таракитос", затем эта реплика, затем PetrDidenko отвечает.
+        Это Umputun произносит ник по буквам для розыгрыша в чате.
+      identified_as: "umputun"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        8149s Umputun: "Таракитос."
+        8153s SPEAKER_00: "Т-А-Р-А-К-И-Т-И-К-О-С." (побуквенно)
+        8159s PetrDidenko: "Слушай, я считаю..."
+        8164s Umputun: "Таракитос."
+        Явно Umputun продолжает диктовать ник победителя розыгрыша.
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes: |
+    Все участники представлены в начале выпуска (85-130 сек):
+    - Umputun: ведёт с самого начала (5 сек)
+    - Bobuk: первая реплика 36 сек
+    - Gray: первая реплика 71 сек
+    - PetrDidenko: представлен на 95 сек ("Петя, скажи здрасте")
+    - Marin_k_a: представлена на 116 сек ("Марусенька, ты с нами?")
+  issues: []
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 300
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Umputun"
+    confidence: high
+    reason: |
+      Единственная реплика "Итак, я пишу стоп" явно принадлежит Umputun -
+      Bobuk сразу после обращается "Жень".
+
+  - type: rename
+    episode: 300
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Umputun"
+    confidence: high
+    reason: |
+      Побуквенное произношение "Т-А-Р-А-К-И-Т-И-К-О-С" следует за репликой Umputun "Таракитос" -
+      это он диктует ник победителя розыгрыша.
+
+  - type: rename
+    episode: 300
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Marin_k_a"
+    confidence: high
+    reason: |
+      Реплика "Мы можем просто разыграть" окружена репликами Marin_k_a и продолжает её мысль.
+      Lavale не участвовала в выпуске 300.
+
+  - type: delete_misattribution_marker
+    episode: 300
+    speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    confidence: medium
+    reason: |
+      Эльдар не участвовал в выпуске. Первая реплика ("Вот я пишу") - точно Umputun
+      (Bobuk подтверждает: "пока Женя там пишет"). Остальные две неясны, но тоже не Эльдар.
+    suggested_action: |
+      Переименовать первую реплику (4201s) в Umputun.
+      Две другие требуют дополнительного анализа контекста.
+
+  - type: ignore
+    episode: 300
+    speaker: "SPEAKER_06"
+    confidence: medium
+    reason: |
+      6 очень коротких реплик (0.1-1.7 сек) разбросаны по выпуску.
+      Это типичные ошибки распознавания - подхватки и междометия.
+      Недостаточно данных для точной атрибуции без voice comparison.

--- a/validation/episodes/0300-0399/0301.yaml
+++ b/validation/episodes/0300-0399/0301.yaml
@@ -1,0 +1,257 @@
+episode: 301
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [Ksenks]
+  total_duration_sec: 6500
+  notes: |
+    Это первое появление Ksenks на подкасте (11 августа 2012).
+    Umputun представляет её как "девушку-ведущую" в начале выпуска.
+    Она представляется: "Меня зовут Ксения" (56.58s).
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 383
+    replies_count: 70
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Явное представление на 56.58s: "Меня зовут Ксения, и добрый вечер всем."
+        Umputun на 32.89s спрашивает: "Кто ты прекрасно не знаком?"
+        Bobuk на 49.4s: "Вот мы сейчас узнаем, как качельку зовут."
+        Это первое появление Ksenks на подкасте.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 169
+    replies_count: 82
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Реплики SPEAKER_00 идут вперемешку с Marin_k_a (которая = Ksenks).
+        Примеры совместных реплик:
+        - 53.2s SPEAKER_00: "Не знаю, как зовут качельку..."
+        - 56.58s Marin_k_a: "Меня зовут Ксения..." (продолжение диалога)
+        - 283.88s Marin_k_a: "Да, страничка очень красиво выглядит."
+        - 286.88s SPEAKER_00: "Шикарная." (продолжение той же мысли)
+        Обе метки относятся к одному голосу - Ксении (Ksenks).
+
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 0
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Две ультракороткие реплики ("Угу" на 375s, "Да" на 735s).
+        Длительность 0.08 и 0.06 секунд - артефакты распознавания.
+        Невозможно определить спикера, скорее всего Ksenks или один из ведущих.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Короткие подтверждения в диалоге, может быть любой участник"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Bobuk активно ведёт обсуждение в этих моментах"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 3
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Реплика на 454.68s: "Через Y. Ну, который текстовый совсем."
+        Это ответ на вопрос Bobuk (452.27s): "Lynx в смысле через I или через Y?"
+        Контекст: Marin_k_a (444.31s) говорила про Lynx.
+        Lavale не упоминается в этом выпуске - это ошибочная атрибуция.
+        По контексту это скорее всего Ksenks (продолжает свою мысль про Lynx).
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.8
+          reason: "Продолжение её же мысли про Lynx"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 454.68
+          etime: 457.4
+          text: "Через Y. Ну, который текстовый совсем."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 4
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Реплика на 1248.58s: "А Mac-пользователи говорят, что все, этот проект умер."
+        Контекст: Marin_k_a (1238.99s) говорит про Open Source и реакцию Linux-пользователей.
+        Следующая реплика Marin_k_a (1252.92s): "Как вот сейчас мы про TextMate."
+        Это продолжение одной мысли Ksenks, разбитой транскрипцией.
+        Petr Didenko не упоминается в этом выпуске.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.9
+          reason: "Продолжение фразы Marin_k_a про Open Source"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Реплика на 1495.17s: "Задняя память, хорошо, молодец."
+        Это комментарий-подколка к фразе Bobuk (1471s) про "заднюю память".
+        Тон ироничный, характерный для мужского ведущего.
+        Eldar Murtazin не присутствует в этом выпуске.
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.6
+          reason: "Ироничный комментарий, характерный для Umputun"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Может быть самоирония Bobuk"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1495.17
+          etime: 1497.47
+          text: "Задняя память, хорошо, молодец."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Marin_k_a"
+      issue: |
+        Неправильная метка спикера. Должно быть Ksenks.
+        Вероятно "Marin_k_a" - артефакт транскрипции или ошибочная связь с другим человеком.
+    - speaker: "SPEAKER_00"
+      issue: |
+        Автоматическая метка, должна быть Ksenks.
+        82 реплики неправильно атрибутированы.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 301
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Явное представление: "Меня зовут Ксения" (56.58s).
+      Это первое появление Ksenks на подкасте (2012).
+
+  - type: rename
+    episode: 301
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Реплики перемежаются с Marin_k_a и являются частью того же диалога.
+      Контекст показывает, что это один и тот же голос.
+
+  - type: rename
+    episode: 301
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Продолжение фразы Marin_k_a про Open Source (1238-1254s).
+      Petr Didenko не участвует в этом выпуске.
+
+  - type: rename
+    episode: 301
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      Ответ на вопрос про Lynx после реплики Marin_k_a.
+      Lavale не участвует в этом выпуске.
+
+  - type: delete
+    episode: 301
+    from_speaker: "SPEAKER_03"
+    to_speaker: null
+    confidence: medium
+    reason: |
+      Ультракороткие реплики (0.08s, 0.06s) без содержания.
+      Артефакты распознавания, можно удалить или оставить.
+
+# Примечания
+notes: |
+  Эпизод 301 - исторически важный: первое появление Ksenks (Ксении).
+
+  Главные проблемы:
+  1. Ksenks размечена как "Marin_k_a" (70 реплик) - требует исправления
+  2. Часть реплик Ksenks попала в SPEAKER_00 (82 реплики) - требует исправления
+  3. Одиночные реплики ошибочно атрибутированы Petr, Lavale, Eldar - требует исправления
+
+  После применения правил очистки все 152+ реплики гостя будут правильно
+  атрибутированы Ksenks.

--- a/validation/episodes/0300-0399/0302.yaml
+++ b/validation/episodes/0300-0399/0302.yaml
@@ -1,0 +1,87 @@
+episode: 302
+status: clean
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  total_duration_sec: 6648.6
+  notes: >
+    Парный выпуск. Bobuk ведёт из машины по 3G с iPad, что объясняет
+    возможные артефакты распознавания из-за нестабильного соединения.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 2.1
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Две очень короткие реплики (0.14 сек и 2 сек), разбросанные по эпизоду.
+        Первая "Они" (504.9s) — обрыв фразы между репликами Umputun.
+        Вторая "Да ты шо?" (7185.5s) — характерная реакция, скорее всего Bobuk,
+        но ошибочно выделена как отдельный спикер из-за плохого 3G соединения.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.7
+          reason: >
+            "Да ты шо?" — типичная фраза Bobuk, реплика звучит сразу после его слов
+            об операционных системах Samsung. Bobuk вёл из машины по 3G, что могло
+            вызвать артефакты распознавания.
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 0.2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Единственная реплика "Да." длительностью 0.18 сек между двумя репликами
+        Umputun. Типичная ошибка распознавания — короткое междометие, выделенное
+        как отдельный спикер.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.6
+          reason: >
+            Короткое "Да." как подтверждение слов Umputun о десятиминутном подкасте.
+            Bobuk был в эфире, мог коротко отреагировать.
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues: []
+  notes: >
+    В начале эпизода (0-100 сек) Umputun объясняет, что выпуск "парный" — только
+    он и Bobuk. Bobuk подтверждает, что ведёт из машины по 3G с iPad. Других
+    участников в этом выпуске нет. Все неизвестные спикеры — артефакты
+    распознавания.
+
+# Предлагаемые правила очистки
+suggested_rules: []
+# Правила не нужны — реплики слишком короткие и не несут смысловой нагрузки.
+# При желании их можно удалить или объединить с ближайшими репликами ведущих,
+# но это не критично для качества данных.

--- a/validation/episodes/0300-0399/0303.yaml
+++ b/validation/episodes/0300-0399/0303.yaml
@@ -1,0 +1,165 @@
+episode: 303
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [EldarMurtazin, Marin_k_a]
+  total_duration_sec: 8200  # ~2h17m
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 1283
+    replies_count: 306
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "eldar_murtazin"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "Umputun на 38-41s: 'Пришел в гости Эльдар, который как-то давно за разу не захаживал'. EldarMurtazin отвечает на 42s: 'Ой, я зараза такая, вот мотаюсь... Я был в Антарктиде'"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 631
+    replies_count: 199
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "На 178s EldarMurtazin говорит 'даже Маринку привел удаленную'. На 186s 'Маринка, вернись'. Umputun на 1623s обращается 'Марусенька'. На 161s Umputun говорит 'Вот этим квинтетом мы выступим' (5 человек: 3 ведущих + Эльдар + Марина)"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 23
+    replies_count: 12
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие разрозненные реплики (1-4 сек каждая) в случайные моменты. Типичные фразы-реакции: 'Мой мальчик', 'Самсунг', 'Молчу', 'Как золото', 'Эльдар', 'Негодяй'. Это ошибки распознавания кратких реплик одного из присутствующих ведущих/гостей."
+      identified_as: null
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Некоторые реплики (например 'Мой мальчик' на 1679s) идут сразу после обращения к сыну Umputun, могут быть репликой Марины. На 7189s 'Эльдар' - обращение к Эльдару, скорее Марина."
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Gray присутствует, но говорит меньше всех ведущих (193 реплики vs 803 у Umputun). Часть реплик может быть его."
+      voice_task:
+        needed: false
+        reason: "Реплики слишком короткие (<2 сек) для надёжного сравнения голоса"
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 8
+    replies_count: 5
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "5 коротких реплик, две группы: 1) на 2213-2219s три реплики 'Простая крестьянская смекалка', 'Что с ним делать?', 'Да' - идут между репликами Marin_k_a о 'копать картошку'; 2) на 8135-8138s две реплики 'И вообще уходи', 'Я вообще молчал' - идут после реплики Marin_k_a про слушателей. Вероятно ошибка атрибуции реплик Marin_k_a."
+      identified_as: null
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.7
+          reason: "Обе группы реплик находятся в диалогах с Marin_k_a и стилистически похожи на её манеру речи"
+        - person_id: "eldar_murtazin"
+          confidence: 0.2
+          reason: "Эльдар также присутствует в диалогах, может быть его реакция"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2213.29
+          etime: 2217.88
+          text: "Ну, вот знаешь, есть у... Простая крестьянская смекалка."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 8
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+      note: "Это уже отмеченные как ошибочно атрибутированные реплики. Контекст показывает что это реплики Marin_k_a:"
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1) На 1628s 'Давай я расскажу это в виде истории' - сразу после обращения Umputun 'Марусенька, я хотел бы твое услышать', адресат очевиден
+        2) На 3921s 'Если бы у меня чат был, я бы с удовольствием' - ответ на просьбу Bobuk 'Марусечка, мне кажется, что ты должна объяснить чату...'
+        3) Третья реплика на 4186s 'Последнее время, да' - в том же диалоге
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_06"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Единственная реплика 'Как слышать' длиной 1.3 сек на 5921s. Слишком короткая и изолированная для идентификации. Скорее всего ошибка распознавания одного из участников."
+      identified_as: null
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Фраза 'Как слышать' может быть технической репликой ведущего про звук/связь"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Марина участвует удалённо, могут быть проблемы со связью"
+      voice_task:
+        needed: false
+        reason: "Реплика слишком короткая (1.3 сек) для voice comparison"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes:
+    - "Umputun представил Эльдара на 38-41s"
+    - "Марина упомянута Эльдаром на 178s как 'Маринку удалённую'"
+    - "На 161s Umputun говорит 'квинтетом' - подтверждает 5 участников"
+    - "Bobuk и Gray не представлены явно, но это постоянные ведущие"
+  issues:
+    - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+      issue: "Уже помечен как ошибка, но не исправлен. Нужно переименовать в Marin_k_a"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 303
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Marin_k_a"
+    confidence: high
+    reason: "Все 3 реплики идут сразу после прямого обращения к Марине ('Марусенька', 'Марусечка')"
+
+  - type: rename
+    episode: 303
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Marin_k_a"
+    confidence: medium
+    reason: "Реплики находятся в контексте диалогов Марины, но требуется voice comparison для подтверждения"
+
+# Итоговые замечания
+notes: |
+  Эпизод 303 от 25 августа 2012 года.
+  Состав: Umputun, Bobuk, Gray + гости EldarMurtazin и Marin_k_a (удалённо).
+
+  Основные гости (EldarMurtazin, Marin_k_a) уже правильно идентифицированы в транскрипте.
+
+  Проблемные спикеры:
+  - SPEAKER_MISATTRIBUTED_LAVALE (3 реплики) - это Marin_k_a, можно переименовать с высокой уверенностью
+  - SPEAKER_04 (5 реплик) - вероятно Marin_k_a, нужна проверка
+  - SPEAKER_00 (12 реплик) и SPEAKER_06 (1 реплика) - слишком короткие для идентификации,
+    скорее всего ошибки распознавания разных участников

--- a/validation/episodes/0300-0399/0304.yaml
+++ b/validation/episodes/0300-0399/0304.yaml
@@ -1,0 +1,198 @@
+episode: 304
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Ksenks]  # первый гиковский выпуск Ксении
+  total_duration_sec: 7250  # ~2 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 299
+    replies_count: 106
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. В 74с Umputun представляет: "Ксения. Ксюша." -> сразу SPEAKER_00 отвечает "Привет" (76с)
+        2. В 976с: "Ксения, ты с нами или ты заснула?" -> SPEAKER_00 отвечает "Нет, нет, мне очень интересно"
+        3. В 1343с SPEAKER_00 говорит "в первом же выпуске" — это её первый гиковский выпуск
+        4. Чередуется с Marin_k_a в одних диалогах, продолжая друг друга
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 346
+    replies_count: 48
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Ошибочная атрибуция. В эпизоде 304 нет Марины (Marin_k_a).
+        Это Ксения (Ksenks) — её первый гиковский выпуск.
+        Система распознавания ошибочно разделила реплики Ксении между
+        SPEAKER_00 и Marin_k_a. Реплики чередуются в одних диалогах,
+        продолжая мысль друг друга (см. 1750-1778с про шардинг).
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. Umputun представляет только Ксению, не Марину
+        2. Marin_k_a и SPEAKER_00 чередуются в одном разговоре (1754-1778с)
+        3. Контекст реплик показывает одного человека, а не двух
+        4. В эпизоде упоминается только Ксюша/Ксения
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 3
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Ранее ошибочно атрибутировано как Lavale, затем отменено.
+        Реплика "Например, посылку каких-то данных по сети" (6797с)
+        находится между репликами SPEAKER_00 (=Ksenks) и продолжает её мысль.
+        Lavale не участвовала в этом эпизоде.
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Окружающий контекст (6793-6805с):
+        - SPEAKER_00: "Но есть же такие действия, которые вообще в принципе нельзя откатить."
+        - MISATTRIBUTED_LAVALE: "Например, посылку каких-то данных по сети."
+        - SPEAKER_00: "Ты уже никак их не откатишь, если ты их уже послал."
+        Это единый диалог одного человека (Ksenks).
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.75
+          reason: "Продолжение мысли, окружена репликами SPEAKER_00=Ksenks"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6793.3
+          etime: 6805.15
+          text: "Но есть же такие действия... Например, посылку... Ты уже никак их не откатишь..."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Ранее ошибочно атрибутировано как Eldar, затем отменено.
+        Короткая реплика "Я не очень знаю" (7437с) между репликами Bobuk.
+        Эльдар Муртазин не участвовал в этом эпизоде.
+
+      identified_as: null
+      identification_method: null
+      confidence: low
+      evidence: |
+        Контекст (7436-7442с):
+        - Bobuk: "Поэтому посмотрим."
+        - MISATTRIBUTED_ELDAR: "Я не очень знаю."
+        - Bobuk: "Посмотрим, может быть, они что-то реально делают."
+        Слишком короткая реплика для точной идентификации.
+        Может быть Bobuk (продолжение), Ksenks, или ошибка распознавания.
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Между его репликами, может быть часть его речи"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Активный участник эпизода"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 7436.35
+          etime: 7442.2
+          text: "Поэтому посмотрим. Я не очень знаю. Посмотрим, может быть..."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Marin_k_a"
+      issue: "Ошибочная атрибуция: должно быть Ksenks"
+    - speaker: "SPEAKER_00"
+      issue: "Не переименован в Ksenks"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 304
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun представляет Ксению в начале эпизода (74с),
+      SPEAKER_00 отвечает. Прямое обращение "Ксения, ты с нами?" (976с)
+      -> ответ SPEAKER_00. Её первый гиковский выпуск.
+
+  - type: rename
+    episode: 304
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Марина не участвовала в этом эпизоде.
+      Все реплики Marin_k_a принадлежат Ксении.
+      Система ошибочно разделила реплики между SPEAKER_00 и Marin_k_a.
+
+  - type: rename
+    episode: 304
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      Реплика является частью диалога Ksenks (контекст 6793-6805с).
+      Lavale не участвовала в эпизоде 304.
+
+  - type: needs_verification
+    episode: 304
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: null
+    confidence: low
+    reason: |
+      Слишком короткая реплика (2с) для точной идентификации.
+      Требуется voice comparison или ручная проверка.
+      Вероятные кандидаты: Bobuk, Ksenks.
+
+# Примечания
+notes: |
+  Эпизод 304 — первый гиковский выпуск с участием Ксении (Ksenks).
+  Дата: 1 сентября 2012 года (День знаний).
+
+  Основная проблема: система распознавания разделила реплики Ксении
+  между тремя идентификаторами (SPEAKER_00, Marin_k_a, SPEAKER_MISATTRIBUTED_LAVALE).
+
+  После применения правил очистки все 154+ реплики (SPEAKER_00: 106, Marin_k_a: 48,
+  MISATTRIBUTED_LAVALE: 1) должны быть атрибутированы как Ksenks.

--- a/validation/episodes/0300-0399/0305.yaml
+++ b/validation/episodes/0300-0399/0305.yaml
@@ -1,0 +1,153 @@
+episode: 305
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7745
+  notes: |
+    Эпизод от 8 сентября 2012 года. В конце Umputun говорит "полтора ведущих",
+    что указывает на неполный состав. Гость Alexmak (SPEAKER_04) и кандидат
+    в ведущие Marin_k_a (проходила кастинг).
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 2667
+    replies_count: 395
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "alexmak"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Многократные обращения "Алекс" к этому спикеру:
+        - 27s: "Алекс, так ли это?"
+        - 7660s: "Спасибо, Алекс, что пришел." (прощание в конце)
+        Контекст: специалист по Apple/Mac, обсуждает технологии.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 9
+    replies_count: 9
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие односложные реплики ("Нет", "Пока") разбросаны по эпизоду.
+        Обращение "Алик" (6683s) скорее всего к Alexmak (сокращение от Алекс).
+        Реплики в 6686-6691s ("Да я же вообще не программист", "Я не по этим делам")
+        скорее принадлежат Alexmak, но распознаны как отдельный спикер.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "alexmak"
+          confidence: 0.7
+          reason: |
+            Обращение "Алик" к этому спикеру, что похоже на уменьшительное от Алекс.
+            Реплики появляются в диалогах где до/после говорит Alexmak (SPEAKER_04).
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6686.26
+          etime: 6691.37
+          text: "Да я же вообще не программист. Ты так погулять вышел? Я не по этим делам."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 5
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика "Мне кажется, это очень здорово" (577s) между
+        репликами SPEAKER_04 и Marin_k_a. Вероятно ошибка распознавания -
+        может принадлежать любому из трёх присутствующих (Umputun, Alexmak, Marin_k_a).
+        Маркер MISATTRIBUTED указывает на отменённое ошибочное присвоение.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Следующая реплика (583s) принадлежит Marin_k_a на ту же тему"
+        - person_id: "alexmak"
+          confidence: 0.3
+          reason: "Предыдущая реплика (570s) принадлежит SPEAKER_04 (Alexmak)"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 577.34
+          etime: 582.83
+          text: "Мне кажется, это очень здорово."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Marin_k_a"
+      issue: |
+        К ней обращаются как "Ксюша" в тексте (строки 433, 469, 694 и др.),
+        но согласно people.yaml её зовут Марина. Возможно путаница с Ksenks,
+        или "Ксюша" - прозвище. Требует проверки.
+    - speaker: "SPEAKER_04"
+      issue: |
+        Представлен как гость в начале (11s: "про него многое говорили"),
+        но формального представления по имени нет. Идентификация по обращениям.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 305
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Alexmak"
+    confidence: high
+    reason: |
+      Многократные прямые обращения "Алекс" + прощание "Спасибо, Алекс, что пришел"
+      в конце эпизода. Alexmak известен как специалист по Apple (выпуски 196, 203).
+
+  - type: merge
+    episode: 305
+    from_speaker: "SPEAKER_03"
+    to_speaker: "Alexmak"
+    confidence: medium
+    reason: |
+      Обращение "Алик" (уменьшительное от Алекс), короткие реплики в контексте
+      диалогов с участием Alexmak. Требует voice comparison для подтверждения.
+
+# Дополнительные заметки
+notes: |
+  Эпизод 305 от 8 сентября 2012 года. Особенности:
+
+  1. Марина (Marin_k_a) проходит кастинг на ведущую - это её ранний выпуск
+  2. Alexmak - гость, известный Apple-энтузиаст
+  3. Umputun в конце говорит "полтора ведущих" - состав неполный
+  4. Обращения "Ксюша" к кому-то из участниц требуют уточнения
+
+  Для полного закрытия нужно:
+  - Voice comparison для SPEAKER_03 vs Alexmak
+  - Уточнение по обращению "Ксюша" (к кому?)
+
+  URL аудио: недоступен (файл метаданных не найден в data_clean)

--- a/validation/episodes/0300-0399/0306.yaml
+++ b/validation/episodes/0300-0399/0306.yaml
@@ -1,0 +1,225 @@
+episode: 306
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun]
+  guests_present: [Olyapka, Ksenks]  # Обе размечены как Marin_k_a - КРИТИЧЕСКАЯ ОШИБКА
+  total_duration_sec: 8170  # ~2h 16min
+
+# КРИТИЧЕСКАЯ ПРОБЛЕМА: Неверная разметка гостей
+critical_issue:
+  description: |
+    В эпизоде участвуют ДВЕ гостьи - Оля (Olyapka) и Ксения (Ksenks),
+    но ВСЕ их реплики размечены как Marin_k_a.
+    Это явная ошибка - Марина (Marin_k_a) НЕ участвовала в этом выпуске.
+  evidence:
+    - time: 48s
+      umputun_says: "Здравствуй, Оля."
+      marked_as: Marin_k_a
+    - time: 55s
+      umputun_says: "Это я про тебя, Ксюша, говорю."
+      marked_as: Marin_k_a
+    - time: 8082s
+      umputun_says: "Была с нами вновь Оля."
+    - time: 8091s
+      umputun_says: "И была с нами не вновь Ксения."
+  conclusion: |
+    Нужно voice comparison чтобы разделить реплики Olyapka и Ksenks.
+    Текущая разметка Marin_k_a полностью неверна.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 3737
+    replies_count: 868
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Марина (Marin_k_a) НЕ участвовала в этом выпуске.
+        Реальные участницы - Olyapka (Оля) и Ksenks (Ксения).
+        Это массовая ошибочная разметка ~868 реплик.
+
+      identified_as: null  # Требуется разделение на двух спикеров
+      identification_method: null
+      confidence: null
+      evidence: |
+        Umputun обращается к "Оле" (48s, 883s, 1144s, 3601s, 4105s, 7885s, 12853s)
+        и к "Ксении/Ксюше" (55s, 181s, 478s, 694s, 721s, 1018s, 1513s, 1936s).
+        В конце выпуска (8082s): "Была с нами вновь Оля" и "была с нами не вновь Ксения".
+
+      voice_task:
+        needed: true
+        note: |
+          Требуется полная переразметка. Нужно:
+          1. Установить референс голоса Olyapka и Ksenks из других эпизодов
+          2. Разделить ~868 реплик между ними
+        reference_episodes:
+          olyapka: [55, 56, 57, 58, 59]  # Проверить people.yaml для точных эпизодов
+          ksenks: [300, 301, 302, 303, 304, 305]  # Ksenks была регулярной участницей
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 59
+    replies_count: 10
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null  # Вероятно Ksenks, но нужна проверка
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Технически грамотные реплики про iPhone/iPad (2598s: "iPad – это была ретина...").
+        Продолжает мысль предыдущего спикера (Marin_k_a, который на самом деле Ksenks или Olyapka).
+        Контекст указывает на опытного пользователя Apple-техники.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "Технически грамотные реплики, знание Apple-экосистемы"
+        - person_id: "olyapka"
+          confidence: 0.3
+          reason: "Тоже возможно, но менее вероятно по стилю речи"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2598.66
+          etime: 2609.48
+          text: "То есть iPad – это была ретина, которая тоже на тот момент и сейчас, в общем, тоже планшетов с ретиной таких практически нет."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 12
+    replies_count: 4
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null  # Вероятно одна из гостей
+      identification_method: "context"
+      confidence: low
+      evidence: |
+        Короткие реплики в разговоре о системах исчисления (391s: "Она почти так же важна, как двоичная").
+        Возможно Ksenks (техническая тема) или Olyapka.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Техническая тема (системы исчисления)"
+        - person_id: "olyapka"
+          confidence: 0.4
+          reason: "Также возможно"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 391.4
+          etime: 395.42
+          text: "Она почти так же важна, как двоичная. Не так, но почти."
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 24
+    replies_count: 10
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null
+      identification_method: "context"
+      confidence: low
+      evidence: |
+        Короткие реплики-реакции: "Круче" (879s), "Да, это суперзолотой заголовок" (3791s).
+        Вероятно одна из гостей (Ksenks или Olyapka).
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Активная участница обсуждения"
+        - person_id: "olyapka"
+          confidence: 0.4
+          reason: "Также возможно"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3791.18
+          etime: 3796.48
+          text: "Да, это суперзолотой заголовок. Я думаю, будет хороший трафик у выпуска."
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одна реплика "Где секьюрити?" (939s) - вероятно эхо/перебивка.
+        Сразу перед этим Umputun говорит "Где?" и после продолжает "Где, собственно, охрана патентов?".
+        Скорее всего это часть речи Umputun, неправильно разделённая транскрибером.
+
+      identified_as: "umputun"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Контекст (937-943s):
+        - Umputun: "Где?"
+        - SPEAKER_00: "Где секьюрити?"
+        - Umputun: "Где, собственно, охрана патентов?"
+        Это явно один спикер, разбитый на части.
+
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Marin_k_a"
+      issue: |
+        КРИТИЧЕСКАЯ ОШИБКА: Все 868 реплик размечены как Marin_k_a,
+        но реальные участницы - Olyapka и Ksenks.
+        Марина в этом выпуске не участвовала.
+    - speaker: "общая"
+      issue: |
+        Нужна полная переразметка эпизода с voice comparison,
+        чтобы разделить реплики между Olyapka и Ksenks.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  # Пока только SPEAKER_00, остальное требует voice comparison
+  - type: rename
+    episode: 306
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Umputun"
+    confidence: high
+    reason: |
+      Одна реплика "Где секьюрити?" между двумя репликами Umputun -
+      явно часть его речи, неправильно разделённая.
+
+# Задачи для следующего этапа
+next_steps:
+  - priority: critical
+    task: |
+      Получить референсные записи голосов Olyapka и Ksenks из других эпизодов.
+      Olyapka участвовала в выпусках ~55-59.
+      Ksenks - регулярная участница (468 выпусков).
+
+  - priority: critical
+    task: |
+      Выполнить voice comparison для разделения 868 реплик Marin_k_a
+      между реальными участницами Olyapka и Ksenks.
+
+  - priority: medium
+    task: |
+      После разделения основных реплик, определить принадлежность
+      SPEAKER_MISATTRIBUTED_LAVALE, SPEAKER_MISATTRIBUTED_PETR, SPEAKER_03.

--- a/validation/episodes/0300-0399/0307.yaml
+++ b/validation/episodes/0300-0399/0307.yaml
@@ -1,0 +1,224 @@
+episode: 307
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [Lavale, Marin_k_a]
+  new_host_debut: Ksenks  # дебют как постоянная ведущая
+  total_duration_sec: 7800  # ~2h 10min
+
+notes: |
+  Эпизод 307 (22 сентября 2012) — исторический выпуск, в котором представлена
+  новая постоянная ведущая Ksenks (Ксения/Алиса). Gray упоминается как отсутствующий
+  в начале эпизода ("есть еще Грей, но Грей отсутствует"). Присутствуют бывшие
+  ведущие Lavale и Marin_k_a как гости.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 589
+    replies_count: 180
+    pattern: consecutive
+    first_appearance_sec: 252.85
+
+    analysis:
+      is_error: false
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. В 241-250 сек Umputun говорит: "И поэтому мы выбрали самую целебную,
+           самую подходящую нам кандидатку... И приветствуем ее сегодня первый раз
+           в этой студии... в качестве ведущей. Ура!"
+        2. Bobuk говорит "Здравствуй, дорогая" (250.91s), и SPEAKER_02 отвечает "Привет" (252.85s)
+        3. По тексту её называют "Алиса" (например, "Алиса, ты меня не путай" - строки 7651, 10747)
+        4. SPEAKER_02 использует женский род: "Я тоже очень рада" (307.83s),
+           "Я пробежала с глазами" (1798.57s), "я стану ведущей" (5144.57s)
+        5. Ksenks в справочнике people.yaml имеет alias "Ксюша", и в эпизоде
+           упоминается "приходила к Ксюше несколько раз" (204.7s)
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "Lavale"
+    total_duration_sec: 246
+    replies_count: 32
+    pattern: consecutive
+    first_appearance_sec: 322.67
+
+    analysis:
+      is_error: false
+      identified_as: "lavale"
+      identification_method: "already_identified"
+      confidence: high
+      evidence: |
+        Lavale уже идентифицирована в справочнике people.yaml как бывшая ведущая.
+        Присутствует в этом эпизоде как гость вместе с Marin_k_a.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 70
+    replies_count: 11
+    pattern: consecutive
+    first_appearance_sec: 577.07
+
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "already_identified"
+      confidence: high
+      evidence: |
+        Marin_k_a уже идентифицирована в справочнике people.yaml как Марина,
+        бывшая ведущая. В эпизоде есть упоминание "правду про Маринку" (6908.16s).
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "Gray"
+    total_duration_sec: 2
+    replies_count: 2
+    pattern: scattered
+    first_appearance_sec: 185.55
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Gray явно упомянут как ОТСУТСТВУЮЩИЙ в начале эпизода (77.92s):
+        "то есть есть еще Грей, но Грей отсутствует".
+        Две короткие реплики (185.55s "Какие другие?" и 895.10s "Ты будь аккуратней")
+        скорее всего ошибочно атрибутированы — это могут быть реплики Bobuk или Umputun.
+
+      identified_as: null
+      confidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.6
+          reason: "Реплики звучат как комментарии соведущего, Gray отсутствует"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Альтернативный вариант атрибуции"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 185.55
+          etime: 186.19
+          text: "Какие другие?"
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 4
+    replies_count: 1
+    pattern: scattered
+    first_appearance_sec: 7594.97
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика "Или паркуется" (3.5 сек) в конце подкаста (7595s).
+        Вероятно это ошибочно выделенная реплика одного из участников —
+        скорее всего Ksenks (SPEAKER_02), учитывая женский характер комментария.
+
+      identified_as: null
+      confidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: "Стиль комментария похож на SPEAKER_02, активную в этом эпизоде"
+        - person_id: "lavale"
+          confidence: 0.2
+          reason: "Альтернативный вариант — другая женщина-участница"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 7594.97
+          etime: 7598.51
+          text: "Или паркуется."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+    first_appearance_sec: 4100.32
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одна очень короткая обрывочная реплика "Я считаю, что..." (0.52 сек)
+        между двумя репликами Bobuk. Эльдар Муртазин не участвовал в этом эпизоде.
+        Это явно ошибочно отделённая часть речи Bobuk — он говорит
+        "У меня есть по этому поводу теория" (4098.76s), затем идёт этот обрывок,
+        и сразу продолжение Bobuk "Сначала большим-большим-большим злом стала компания IBM" (4101.93s).
+
+      identified_as: null
+      confidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.95
+          reason: "Обрывок между репликами Bobuk, часть его монолога"
+
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Gray"
+      issue: |
+        Gray помечен как спикер (2 реплики), но в начале эпизода явно сказано,
+        что он отсутствует. Требуется проверка — возможно ошибочная атрибуция.
+    - speaker: "SPEAKER_02"
+      issue: |
+        Основная новая ведущая (Ksenks) помечена как SPEAKER_02 вместо
+        канонического имени. Требуется переименование.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 307
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      SPEAKER_02 — это дебют Ksenks как постоянной ведущей. Явное представление
+      в начале эпизода, обращение по имени "Алиса" по ходу подкаста,
+      использование женского рода в речи.
+
+  - type: rename
+    episode: 307
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "Bobuk"
+    confidence: high
+    reason: |
+      Обрывочная реплика (0.52 сек) между двумя репликами Bobuk.
+      Эльдар Муртазин не участвовал в эпизоде.
+
+  - type: investigate
+    episode: 307
+    speaker: "Gray"
+    confidence: medium
+    reason: |
+      Gray объявлен отсутствующим в начале эпизода, но имеет 2 короткие реплики.
+      Требуется voice comparison для определения реального спикера.
+
+  - type: investigate
+    episode: 307
+    speaker: "SPEAKER_03"
+    confidence: medium
+    reason: |
+      Единственная короткая реплика в конце эпизода. Вероятно Ksenks,
+      но требуется подтверждение.

--- a/validation/episodes/0300-0399/0308.yaml
+++ b/validation/episodes/0300-0399/0308.yaml
@@ -1,0 +1,248 @@
+episode: 308
+status: needs_review
+analyzed_at: "2026-01-25T12:00:00Z"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Ksenks]  # Gray отсутствовал по словам Umputun в конце
+  total_duration_sec: 8200  # ~2.3 часа
+  notes: |
+    Эпизод 308 от 29 сентября 2012.
+    Грей "где-то на гулянке, обещался прийти, но не пришел" (слова Umputun в 8092-8095с).
+    Однако в транскрипте есть 7 реплик под именем Gray — требует проверки.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  # SPEAKER_00 - идентифицирован как Ksenks
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 546
+    replies_count: 196
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Umputun прямо обращается: "Ксения, ты тогда как раз пошла в детский сад" (238-246с).
+        В конце эпизода: "Ксюша, ты с нами сегодня была опять без микрофона" (8118-8127с).
+        Реплики SPEAKER_00 следуют после обращений к Ксении.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  # SPEAKER_01 - идентифицирован как гость Виктор
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 547
+    replies_count: 157
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null  # Виктор не в people.yaml, нужно добавить
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Umputun обращается напрямую: "Ты видел, Виктор, что было с американским футболом" (42-47с).
+        "Вот Виктор не даст соврать" (1599-1601с).
+        "Вот попробуй, Виктор, Навигон" (5561-5563с).
+        В конце: "Вместо него [Gray] был Виктор, который не первый раз с нами" (8096-8102с).
+        Виктор сам говорит: "Я уже постоянно приходящий ведущий... пятый раз" (8102-8109с).
+
+      possible_matches: []
+
+      voice_task:
+        needed: true  # Для добавления в people.yaml нужна голосовая выборка
+        reference_segment:
+          stime: 48.97
+          etime: 62.42
+          text: "Нет, я, к сожалению, не владею телевизором, поэтому я не могу следить за этим прекрасным шоу под названием «Американский футбол», в том числе и «Американский баскетбол» и другие шоу."
+
+  # Marin_k_a - уже в справочнике
+  - speaker: "Marin_k_a"
+    total_duration_sec: 204
+    replies_count: 34
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "existing_id"
+      confidence: high
+      evidence: "Уже идентифицирована в people.yaml как бывшая ведущая Марина"
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  # SPEAKER_MISATTRIBUTED_LAVALE - требует идентификации
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 46
+    replies_count: 8
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        8 осмысленных реплик между SPEAKER_00 (Ksenks) и Marin_k_a.
+        Название SPEAKER_MISATTRIBUTED_LAVALE указывает, что раньше было ошибочно
+        атрибутировано как Lavale (бывшая ведущая), но потом отменено.
+        По голосу скорее всего это Ksenks или Marin_k_a.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Реплики появляются в контексте диалога SPEAKER_00 (Ksenks)"
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "Реплики появляются рядом с репликами Marin_k_a"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2042.29
+          etime: 2050.77
+          text: "Окей, давайте я тогда расскажу свои впечатления и потом тоже проверю, где были эти бетчмарки, может быть, какие-то другие у меня были."
+
+  # SPEAKER_MISATTRIBUTED_ELDAR - короткие реплики
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 6
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Только 2 короткие реплики (6 сек) в случайные моменты эпизода.
+        Название указывает на отменённую ошибочную атрибуцию к Eldar Murtazin.
+        Скорее всего ошибка распознавания одного из ведущих или гостей.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Реплики:
+        - 5644с: "У нас, по-моему, в нашей области они запрещены, радары."
+        - 7803с: "А у кого просят-то?"
+        Обе реплики короткие и могут принадлежать любому участнику.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Может быть ошибкой распознавания голоса Ksenks"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Может быть ошибкой распознавания голоса Umputun"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5644.55
+          etime: 5648.5
+          text: "У нас, по-моему, в нашей области они запрещены, радары."
+
+  # SPEAKER_04 - ошибка распознавания
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 1
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Только 2 очень короткие реплики (суммарно ~1 сек).
+        "Угу" (5519с) и "Зачем же лица в камере?" (7315с).
+        Типичные ошибки автоматического распознавания спикеров.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Gray"
+      issue: |
+        В транскрипте есть 7 реплик Gray (46 сек, начиная с 676с),
+        но Umputun в конце эпизода (8092с) говорит:
+        "Грей где-то на гулянке, обещался прийти, но не пришел."
+        Это серьёзное противоречие — либо Gray подключился и ушёл,
+        либо реплики Gray ошибочно атрибутированы другому спикеру.
+        ТРЕБУЕТ РУЧНОЙ ПРОВЕРКИ по голосу.
+    - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+      issue: |
+        8 реплик помечены как "отменённая атрибуция Lavale".
+        Нужно определить, кому они реально принадлежат.
+    - speaker: "Виктор"
+      issue: |
+        Гость Виктор идентифицирован (SPEAKER_01), но его нет в people.yaml.
+        Нужно добавить после подтверждения фамилии (если известна).
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 308
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Прямое обращение Umputun к Ксении, ответы SPEAKER_00 соответствуют контексту"
+
+  - type: rename
+    episode: 308
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Victor"  # или Victor_Guest, пока нет фамилии
+    confidence: high
+    reason: "Прямые обращения по имени Виктор от Umputun в нескольких местах эпизода"
+
+  - type: delete
+    episode: 308
+    from_speaker: "SPEAKER_04"
+    to_speaker: null
+    confidence: medium
+    reason: "Только 2 очень короткие реплики, вероятно ошибки распознавания"
+
+# Требуемые действия
+actions_required:
+  - priority: high
+    action: "voice_comparison"
+    description: |
+      Проверить реплики Gray (676-7832с) по голосу.
+      Если это не Gray, определить реального спикера.
+      Возможно это Виктор или один из ведущих.
+
+  - priority: medium
+    action: "voice_comparison"
+    description: |
+      Проверить SPEAKER_MISATTRIBUTED_LAVALE — определить,
+      это Ksenks или Marin_k_a.
+
+  - priority: low
+    action: "add_to_people_yaml"
+    description: |
+      Добавить гостя Виктора в people.yaml после определения фамилии.
+      Он участвовал минимум в 5 эпизодах по его словам.

--- a/validation/episodes/0300-0399/0309.yaml
+++ b/validation/episodes/0300-0399/0309.yaml
@@ -1,0 +1,345 @@
+episode: 309
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Ksenks, Gray]
+  # Gray присутствует минимально (3 реплики), возможно ошибка распознавания
+  total_duration_sec: 8619  # ~2.4 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 849
+    replies_count: 209
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Гость представлен явно
+      identified_as: null  # Имя "Алексей/Лёха" известно, но person_id неизвестен
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Umputun в 64s: "Дорогой, Алексей."
+        Umputun в 67s: "Он же Леха."
+        Umputun в 71-77s: "Ты нам известен... Ты тут уже был."
+        SPEAKER_00 в 74-76s: "Бывал. Я тут отмечался."
+        Umputun в 77s: "Говорят, ты большой специалист по джавам"
+        Гость активно обсуждает Java, ZFS, технические темы весь выпуск.
+        В конце выпуска (9475s): "Алексей, спасибо, что пришел."
+
+      possible_matches:
+        - person_id: "alek_sys"
+          confidence: 0.4
+          reason: "Имя Алексей/Лёха совпадает, но Alek.sys — постоянный ведущий, а гость представлен как 'уже бывал'"
+        - person_id: null
+          confidence: 0.6
+          reason: "Скорее всего это другой Алексей, не из справочника. Нужен voice comparison"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 458.48
+          etime: 469.1
+          text: "Я как человек близкий к всяким ZFS, хотел бы высказать, что можете делать сколько хотите снапшотов на некоторых файловых системах."
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 527
+    replies_count: 96
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "pre-labeled"
+      confidence: high
+      evidence: "Уже размечена в транскрипте. Марина — бывшая ведущая, указана в people.yaml"
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 235
+    replies_count: 105
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Umputun в начале (8-28s) говорит о Ксюше:
+        "Я даже без Ксюши, которая пришла, как она обычно приходит"
+        "И Ксюша опять пришла, но опять с таким плохим микрофоном"
+        Первая реплика SPEAKER_04 (45s): "Я затаила обиду" — ответ на шутку про "дама".
+        На протяжении выпуска Umputun обращается к Ксюше, и следующие реплики — от SPEAKER_04:
+        - 587s: "Ксюша, ты понимаешь..." → 606s SPEAKER_04: "Как-то они раньше"
+        - 895s: "Ксюша, знаешь, да, проблему?" → 899s SPEAKER_04 отвечает
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 20
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        SPEAKER_MISATTRIBUTED_* — это отменённые ошибочные присвоения.
+        Lavale — бывшая ведущая, но не участвовала в выпуске 309.
+        Реплики (422s, 1660s) скорее всего принадлежат одному из присутствующих.
+        По контексту (1660s про Jenkins и плагины) — вероятно SPEAKER_00 (Алексей).
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: null  # SPEAKER_00 (Алексей)
+          confidence: 0.7
+          reason: "Технический контекст про Jenkins характерен для гостя-Java разработчика"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1660.59
+          etime: 1676.08
+          text: "И вот так исторически сложилось, что он для Jenkins..."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 9
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        SPEAKER_MISATTRIBUTED_ELDAR — отменённое ошибочное присвоение Эльдару Муртазину.
+        Эльдар не участвовал в выпуске 309.
+        Реплики короткие (2088s: "Ну, написал что-то", 9017s: про DNS) — вероятно ошибка распознавания.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Короткие реплики между репликами ведущих, вероятно ошибка сегментации"
+        - person_id: null  # SPEAKER_00
+          confidence: 0.3
+          reason: "Реплика про DNS (9017s) может быть технической вставкой гостя"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 9
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        SPEAKER_MISATTRIBUTED_PETR — отменённое ошибочное присвоение Петру Диденко.
+        Пётр не участвовал в выпуске 309.
+        Реплики короткие и разбросанные (1523s, 3311s, 6973s).
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Короткие вопросы, характерные для ведущего"
+        - person_id: null  # SPEAKER_00
+          confidence: 0.4
+          reason: "Могут быть репликами гостя"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 7
+    replies_count: 4
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Очень короткие реплики (2162s: "Ну, я уважаю людей", 2388-2392s: про тестовую базу и паспорт).
+        Вероятно ошибка сегментации — реплики должны принадлежать одному из ведущих или SPEAKER_00.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "По стилю похоже на короткие вставки Bobuk"
+        - person_id: null  # SPEAKER_00
+          confidence: 0.3
+          reason: "Технический контекст про базу данных"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 3
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Всего 2 реплики по 1-2 секунды каждая:
+        - 6338s: "Темы слушателей." — вероятно джингл или вставка
+        - 8166s: "Молодцы." — короткая реакция
+        Скорее всего ошибка распознавания или аудио-артефакт.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: null  # SPEAKER_99 (артефакт)
+          confidence: 0.7
+          reason: "Темы слушателей" — типичная вставка/джингл"
+        - person_id: "bobuk"
+          confidence: 0.2
+          reason: "Молодцы" может быть репликой ведущего"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Gray"
+    total_duration_sec: 3
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Gray помечен как присутствующий, но имеет только 3 очень короткие реплики:
+        - 3466s: "Я же говорю, гид вручную." (1s)
+        - 4068s: "Так что..." (0.3s)
+        - 6107s: "В 2012 году." (1.4s)
+        Суммарно ~3 секунды на 2.4-часовой подкаст — крайне маловероятно.
+        Вероятно ошибка распознавания — эти реплики принадлежат другому спикеру.
+
+      identified_as: null  # Требует проверки, присутствовал ли Gray вообще
+      identification_method: null
+      confidence: null
+      evidence: |
+        В начале выпуска Umputun не упоминает Gray среди присутствующих.
+        Говорит только про Ксюшу (Ksenks) и гостя Алексея.
+        Bobuk упоминает "Диму Завалишина", которого ждали, но он не пришёл.
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Короткие вставки могут быть Bobuk"
+        - person_id: null  # SPEAKER_00
+          confidence: 0.3
+          reason: "Могут быть репликами гостя"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3466.09
+          etime: 3467.11
+          text: "Я же говорю, гид вручную."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Gray"
+      issue: |
+        Gray НЕ был представлен/упомянут в начале выпуска.
+        Umputun говорит только про Ксюшу и гостя Алексея.
+        3 реплики по 1 секунде за 2.4 часа — вероятно ошибка разметки.
+        Требуется проверка: присутствовал ли Gray в выпуске 309.
+
+    - speaker: "SPEAKER_00"
+      issue: |
+        Гость Алексей (Лёха) представлен, но не идентифицирован полностью.
+        Известно: специалист по Java/ZFS, уже бывал на подкасте.
+        Не найден в справочнике guests — нужно добавить или найти соответствие.
+
+    - speaker: "Marin_k_a"
+      issue: |
+        Марина присутствует в выпуске, но не была представлена явно.
+        Вероятно её присутствие предполагалось известным слушателям.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 309
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      SPEAKER_04 — это Ксюша (Ksenks). Доказательства:
+      1. Umputun упоминает Ксюшу в начале (8-28s)
+      2. Первая реплика SPEAKER_04 (45s) — ответ на шутку про "дама"
+      3. Umputun обращается к Ксюше, и SPEAKER_04 отвечает
+
+  - type: rename
+    episode: 309
+    from_speaker: "SPEAKER_05"
+    to_speaker: "SPEAKER_99"
+    confidence: medium
+    reason: |
+      "Темы слушателей" (6338s) — типичный джингл/вставка.
+      Должен быть помечен как SPEAKER_99 (артефакт).
+
+  - type: investigate
+    episode: 309
+    from_speaker: "Gray"
+    to_speaker: null
+    confidence: medium
+    reason: |
+      Требуется проверка: присутствовал ли Gray в выпуске 309.
+      Только 3 реплики по ~1 секунде — вероятно ошибка разметки.
+      Если не присутствовал — реплики нужно переназначить.
+
+  - type: investigate
+    episode: 309
+    from_speaker: "SPEAKER_00"
+    to_speaker: null
+    confidence: medium
+    reason: |
+      Гость Алексей/Лёха идентифицирован по имени, но не найден в people.yaml.
+      Варианты:
+      1. Добавить нового гостя "aleksey_java" или подобное
+      2. Найти в истории подкаста, кто этот Алексей (бывал раньше)
+      3. Voice comparison с другими Алексеями в архиве

--- a/validation/episodes/0300-0399/0310.yaml
+++ b/validation/episodes/0300-0399/0310.yaml
@@ -1,0 +1,223 @@
+episode: 310
+status: has_tasks
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [Marin_k_a]
+  total_duration_sec: ~7200  # ~2 hours based on timestamps
+  notes: >
+    В начале Umputun объявляет состав: "Бобук, Ксюша и ваш покорный слуга",
+    но называет Марину (Marin_k_a) Ксюшей — вероятно шутка или ошибка.
+    Ksenks в этом выпуске отсутствует.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 599
+    replies_count: 198
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: >
+        Реплики SPEAKER_03 перемежаются с репликами Marin_k_a в одних и тех же диалогах
+        (например, строки 2293-2314: SPEAKER_03 → Marin_k_a → SPEAKER_03 в непрерывном разговоре).
+        Это явно один человек, разбитый на две сущности автораспознаванием.
+        Стиль речи идентичен. В выпуске только одна женщина.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 444
+    replies_count: 81
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "existing_label"
+      confidence: high
+      evidence: >
+        Уже правильно размечена в people.yaml как бывшая ведущая.
+        В начале эпизода представлена как "Ксюша" (вероятно, шутка Umputun).
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 22
+    replies_count: 14
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: >
+        Реплика "Я бы сходила" (2648s) — женский род, в выпуске только одна женщина (Марина).
+        Остальные реплики вписываются в тот же паттерн — короткие вопросы/комментарии.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 33
+    replies_count: 8
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Метка SPEAKER_MISATTRIBUTED_* означает, что ранее реплика была ошибочно
+        атрибутирована другому человеку (Lavale), потом это исправление было отменено.
+        Lavale участвовала в других выпусках, но не в этом.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.7
+          reason: >
+            В выпуске только три участника: Umputun, Bobuk, Marin_k_a.
+            Реплики скорее всего принадлежат Марине или одному из ведущих.
+        - person_id: "bobuk"
+          confidence: 0.2
+          reason: "Некоторые реплики могут принадлежать Бобуку (например, про HTML5)."
+        - person_id: "umputun"
+          confidence: 0.1
+          reason: "Маловероятно, но возможно."
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2700.09
+          etime: 2710.17
+          text: "То есть, насколько я сейчас понимаю, HTML5, ну, оно еще не в таком вот прямо состоянии, когда можно просто взять и полностью заменить Flash везде."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 8
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Единственная реплика, ранее ошибочно атрибутированная Петру Диденко.
+        Пётр не участвовал в этом выпуске.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Женский участник в выпуске."
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Мог быть Бобук, обсуждающий Flash."
+        - person_id: "umputun"
+          confidence: 0.2
+          reason: "Возможно Umputun."
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2913.2
+          etime: 2921.23
+          text: "Ну, то есть это так сложно реализовать все 20%, значит, непонятно будет, как переходить с этого флэша на что-то другое."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Единственная очень короткая реплика "Все гораздо проще." (1.27 сек).
+        Эльдар Муртазин не участвовал в этом выпуске.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Реплика следует сразу после Бобука, может быть его продолжением."
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Женский участник."
+        - person_id: "umputun"
+          confidence: 0.2
+          reason: "Возможно."
+
+      voice_task:
+        needed: false  # Слишком короткая реплика для voice comparison
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Marin_k_a"
+      issue: >
+        Umputun объявил "Бобук, Ксюша и ваш покорный слуга", но на самом деле вместо
+        Ksenks участвует Marin_k_a. Либо это шутка, либо в 2012 году "Ксюша" было
+        альтернативным именем для Марины. Требует уточнения.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 310
+    from_speaker: "SPEAKER_03"
+    to_speaker: "Marin_k_a"
+    confidence: high
+    reason: >
+      SPEAKER_03 и Marin_k_a — один человек, разделённый автораспознаванием.
+      198 реплик SPEAKER_03 должны быть объединены с Marin_k_a.
+
+  - type: rename
+    episode: 310
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Marin_k_a"
+    confidence: high
+    reason: >
+      SPEAKER_02 использует женский род ("Я бы сходила"), в выпуске одна женщина.
+      14 реплик принадлежат Марине.
+
+  - type: review_needed
+    episode: 310
+    speakers: ["SPEAKER_MISATTRIBUTED_LAVALE", "SPEAKER_MISATTRIBUTED_PETR", "SPEAKER_MISATTRIBUTED_ELDAR"]
+    reason: >
+      Эти метки означают ранее отменённые ошибочные атрибуции.
+      Нужно voice comparison чтобы определить кому реально принадлежат реплики:
+      Marin_k_a, Bobuk или Umputun.

--- a/validation/episodes/0300-0399/0311.yaml
+++ b/validation/episodes/0300-0399/0311.yaml
@@ -1,0 +1,179 @@
+episode: 311
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray, Ksenks]
+  total_duration_sec: 7690
+  notes: >
+    Ksenks присутствует в эпизоде (явно представлена в начале как "Ксюша"),
+    но её реплики размечены как Marin_k_a и SPEAKER_00.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 264
+    replies_count: 43
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: >
+        В начале эпизода (91.45s) Umputun говорит: "У нас есть Ксюша сегодня".
+        На протяжении эпизода ведущие обращаются к этому спикеру как "Ксюша":
+        - 636.76s: "Ксюша, скажи мне вот что" -> следующая реплика Marin_k_a
+        - 1544.19s: "Видела ли ты, Ксюша, картинки Google дата-центра?"
+        - 3700s: "Ксюша, не уходя от микрофона далеко..."
+        - Многие другие обращения по имени "Ксюша"
+
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 223
+    replies_count: 69
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: >
+        SPEAKER_00 и Marin_k_a чередуются в одних и тех же диалогах, отвечая на
+        обращения к "Ксюше". Например:
+        - 1544s: Umputun спрашивает "Видела ли ты, Ксюша..." -> SPEAKER_00 отвечает "Видела"
+        - Реплика 8240.8s: "Я задала вопрос" - женский род подтверждает идентификацию
+        - SPEAKER_00 продолжает мысли Marin_k_a и наоборот (одна речь разбита между двумя метками)
+        Суммарно Marin_k_a + SPEAKER_00 = 112 реплик, 487 сек - типичный объём для соведущей
+
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 8
+    replies_count: 4
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Эльдар Муртазин НЕ присутствует в этом эпизоде - на него ссылаются в третьем лице
+        ("тебе к Эльдару за такими ответами", "любимая Эльдаром компания").
+        Метка MISATTRIBUTED указывает, что эти реплики были ошибочно присвоены.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: >
+            Учитывая контекст и то, что все другие неизвестные спикеры - это Ksenks,
+            вероятно эти 4 реплики тоже принадлежат ей. Однако без voice comparison
+            нельзя быть уверенным - могут быть и ошибки распознавания других ведущих.
+        - person_id: "gray"
+          confidence: 0.3
+          reason: >
+            Реплика 4360.8s ("Есть 2 терабайта сейлота, 256 solid-state drive")
+            идёт сразу после Gray и продолжает технический диалог.
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3867.68
+          etime: 3869.28
+          text: "Kindle Fire понятно, почему продается."
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Единственная короткая реплика (1.5 сек) "Что и всегда." в середине диалога.
+        Типичная ошибка автоматического распознавания - неправильно атрибутированная
+        короткая фраза одного из ведущих.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: >
+            Реплика идёт сразу после Bobuk (4108-4110s) и перед Gray.
+            Может быть продолжением его мысли.
+        - person_id: "gray"
+          confidence: 0.4
+          reason: Следующая реплика Gray, возможно начал говорить раньше.
+
+      voice_task:
+        needed: false  # слишком короткий сегмент для идентификации
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Ksenks"
+      issue: >
+        Ксения представлена в начале эпизода, но её реплики размечены
+        как Marin_k_a (43 реплики) и SPEAKER_00 (69 реплик) вместо Ksenks.
+        Требуется переименование.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 311
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: >
+      Явное представление "У нас есть Ксюша сегодня" + многочисленные
+      обращения по имени "Ксюша" к этому спикеру.
+
+  - type: rename
+    episode: 311
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: >
+      SPEAKER_00 отвечает на обращения к "Ксюше", использует женский род
+      ("Я задала вопрос"), чередуется с Marin_k_a в тех же диалогах.
+
+  - type: rename
+    episode: 311
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: >
+      Эльдар не присутствует в эпизоде. Вероятнее всего это Ksenks,
+      но требуется voice comparison для подтверждения.
+
+  - type: rename
+    episode: 311
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Bobuk"  # или Gray - требуется проверка
+    confidence: low
+    reason: >
+      Единственная короткая реплика, контекст неоднозначен.
+      Требуется voice comparison или можно оставить как есть (незначительно).

--- a/validation/episodes/0300-0399/0312.yaml
+++ b/validation/episodes/0300-0399/0312.yaml
@@ -1,0 +1,169 @@
+episode: 312
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [EldarMurtazin]
+  total_duration_sec: 7398
+  notes: |
+    Marin_k_a размечена как участник, но это ошибка — на самом деле это Ksenks.
+    Umputun многократно называет её "Ксюша" и даже оговаривается "я тебя опять чуть Марусей назвал" (5616s).
+
+# Детальный анализ спикеров
+speaker_analysis:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1175
+    replies_count: 244
+    first_appearance: 18
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Это ошибочная разметка. На самом деле это Ksenks (Ксюша).
+        Доказательства:
+        1. Umputun в начале эпизода (15s): "Но мы, Ксюша, с тобой сдержимся"
+        2. Umputun в (5616s): "Ксюша, я тебя опять чуть Марусей назвал" — прямое признание оговорки
+        3. На протяжении всего эпизода Umputun обращается к ней "Ксюша" (15+ раз)
+        4. В контексте (8030-8031s) Umputun говорит "Маруся, Господи" и она отвечает "Ксюша, так я сказал" — поправляет его
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        - 15.4s: "Но мы, Ксюша, с тобой сдержимся"
+        - 5616.7s: "Ксюша, я тебя опять чуть Марусей назвал"
+        - 8030-8031s: Диалог где Umputun оговаривается "Маруся" и она поправляет на "Ксюша"
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 2030
+    replies_count: 464
+    first_appearance: 639
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "eldar_murtazin"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        - 630.3s [Umputun]: "Да, а у нас подключается Эльдар, который известный аналитик по всяким глупостям"
+        - 637.4s [Umputun]: "Эльдар, с нами?"
+        - 638.8s [EldarMurtazin]: "Привет, с вами."
+
+  - speaker: "Bobuk"
+    total_duration_sec: 1317
+    replies_count: 374
+    first_appearance: 2486
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "bobuk"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        - 2523.8s [Umputun]: "Дорогие же наши, это к нам Бобук присоединился"
+        - 2525.8s: "Вы можете не узнать из-за дуже поганого звука, который у Бобука есть"
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 10
+    replies_count: 3
+    first_appearance: 6326
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Три коротких реплики от разных участников, неправильно размеченные:
+        1. 6326.4s "Естественно" — контекст: Umputun говорит "Ты же знаешь, я вашего брата за бездельника считаю",
+           ответ "Естественно" скорее всего от EldarMurtazin (к нему обращается Umputun)
+        2. 7711.2s и 7718.0s — две реплики подряд про "извращенцев с iPhone", в контексте диалога
+           между Bobuk и кем-то. Судя по содержанию ("Хотя мы не все такие") это скорее всего Ksenks
+      possible_matches:
+        - person_id: "eldar_murtazin"
+          confidence: 0.7
+          reason: "Реплика 6326.4s — ответ на обращение Umputun к Эльдару"
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "Реплики 7711-7718s — женский голос в диалоге"
+      voice_task:
+        needed: true
+        reference_segments:
+          - stime: 6326.4
+            etime: 6327.4
+            text: "Естественно."
+            probable_speaker: "EldarMurtazin"
+          - stime: 7711.2
+            etime: 7719.4
+            text: "Ты знаешь, сейчас большинство тех, кто слушает, мне кажется, подумали, что все, кто пользуется айфонами, извращенцы. Хотя мы не все такие."
+            probable_speaker: "Ksenks"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 3
+    replies_count: 1
+    first_appearance: 2180
+    pattern: single
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одна короткая реплика посреди речи Marin_k_a (которая на самом деле Ksenks).
+        Реплика "В общем, Apple не справляется с тем спросом, который существует" —
+        это продолжение мысли Ksenks о дефиците iPhone (см. контекст 2168-2190s).
+        Метка SPEAKER_MISATTRIBUTED_LAVALE указывает, что это была ошибочная атрибуция Lavale,
+        которую уже отменили, но не переразметили корректно.
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        - 2168.4s [Marin_k_a]: "Это свидетельствует о том, что Apple, наверное, не справляет..."
+        - 2180.0s [SPEAKER_MISATTRIBUTED_LAVALE]: "В общем, Apple не справляется с тем спросом, который существует"
+        - 2185.3s [Marin_k_a]: "Если бы этот дефицит создавался искусственно..."
+        Это одна непрерывная мысль от Ksenks, разбитая ошибкой транскрипции.
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Marin_k_a"
+      issue: |
+        КРИТИЧЕСКАЯ ОШИБКА: Marin_k_a — это неправильная разметка.
+        Участница — Ksenks (Ксюша), что многократно подтверждается в тексте.
+        Вероятно, ошибка произошла при автоматической разметке или при слиянии данных.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 312
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun многократно называет участницу "Ксюша" (15+ раз).
+      Прямое подтверждение в 5616s: "Ксюша, я тебя опять чуть Марусей назвал".
+      Поправка от неё самой в 8031s после оговорки "Маруся".
+
+  - type: rename
+    episode: 312
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Реплика является частью непрерывной речи Ksenks о дефиците iPhone.
+      Контекст до и после принадлежит тому же спикеру.
+
+  - type: rename
+    episode: 312
+    from_speaker: "SPEAKER_01"
+    to_speaker: null
+    confidence: medium
+    reason: |
+      Требуется voice comparison для точной атрибуции.
+      Вероятно: 6326s -> EldarMurtazin, 7711-7718s -> Ksenks.
+
+# Аудио для верификации
+audio_reference:
+  url: null  # Файл 312_desc.json не найден в data_clean
+  note: "Необходимо найти URL аудио в исходных данных для voice comparison"

--- a/validation/episodes/0300-0399/0313.yaml
+++ b/validation/episodes/0300-0399/0313.yaml
@@ -1,0 +1,144 @@
+episode: 313
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 6443  # ~1ч 47мин по статистике
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 896
+    replies_count: 221
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Marin_k_a из people.yaml - бывшая ведущая Марина
+      # Однако в эпизоде её называют "Ксюш" (строка 46: "Не те темы, Ксюш?")
+      # Ksenks в people.yaml имеет alias "Ксюша"
+      # Требуется проверка: это действительно Марина или Ксения?
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: medium
+      evidence: "В people.yaml Marin_k_a = Марина. Но в эпизоде обращение 'Ксюш' (26.33-28.79s). Активно участвует в технических дискуссиях (эксепшны, состояние программ). 221 реплика указывает на ведущую, а не гостя."
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Обращение 'Ксюш' совпадает с alias Ksenks='Ксюша'. Если Marin_k_a неправильно размечена, это может быть Ksenks."
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 845.29
+          etime: 863.15
+          text: "Да. Этот эксепшн прокидывается дальше и дальше. И в каком месте ты его обрабатываешь, это вовсе не то место, в котором она впервые заимитилась. Поэтому получается, что ты не знаешь свое состояние всегда."
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 2
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Две короткие реплики (по ~1 сек) в разных местах: 'Морализонского' (эхо Umputun) и 'Не брала, да' (ответ на обращение 'Ксюша'). Типичная ошибка автоматической разметки - фразы скорее всего принадлежат Marin_k_a или кому-то из ведущих."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.7
+          reason: "Ответ на 'Ксюша, скажи, не брала' - прямое обращение к тому же человеку, которого называют Ксюшей (Marin_k_a в этом эпизоде)"
+        - person_id: "bobuk"
+          confidence: 0.2
+          reason: "Первая реплика 'Морализонского' может быть ответом Bobuk"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 3
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Название спикера указывает на уже отменённое ошибочное присвоение. Одна короткая реплика 'Вы не умеете их готовить, наверное' в контексте обсуждения потоков - скорее всего Marin_k_a или кто-то из ведущих."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Женский голос в разговоре с двумя мужчинами-ведущими. Marin_k_a активно участвует в обсуждении в этот момент."
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Ироничная реплика в стиле Bobuk"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Marin_k_a"
+      issue: "Не найдено явного представления в начале. Участвует с первых секунд как соведущая. Обращение 'Ксюш' вместо 'Марина' требует проверки - возможна путаница с Ksenks."
+    - speaker: "SPEAKER_02"
+      issue: "Автоматическая разметка. 2 короткие реплики - нужно слить с основным спикером (вероятно Marin_k_a)."
+    - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+      issue: "Уже помечено как ошибочное присвоение. Нужно определить реального спикера."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 313
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Marin_k_a"
+    confidence: medium
+    reason: "Обе реплики SPEAKER_02 являются короткими ответами в контексте, где говорит Marin_k_a. Вторая реплика - прямой ответ на обращение 'Ксюша'."
+
+  - type: rename
+    episode: 313
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Marin_k_a"
+    confidence: low
+    reason: "Женский голос в разговоре. Требует voice verification."
+
+# Дополнительные заметки
+notes: |
+  Ключевой вопрос: кто такая Marin_k_a в этом эпизоде?
+
+  В people.yaml:
+  - marin_k_a: canonical_name="Marin_k_a", real_name="Марина", info="Бывшая ведущая"
+  - ksenks: canonical_name="Ksenks", aliases=["Ксюша"], real_name="Ксения", role="Ведущая"
+
+  В эпизоде 313:
+  - Umputun (26.33s): "Не те темы, Ксюш?"
+  - Marin_k_a (28.85s): "Ну, не совсем темы, да."
+
+  Это может означать:
+  1. Marin_k_a = Ksenks (ошибка в разметке всего эпизода)
+  2. Марину называют "Ксюша" как прозвище (маловероятно)
+  3. Ksenks отсутствует, но была упомянута, а ответила Марина
+
+  Рекомендуется voice comparison между:
+  - Marin_k_a в эпизоде 313
+  - Ksenks в других эпизодах
+  - Marin_k_a в других эпизодах
+
+  Если голоса Marin_k_a(313) и Ksenks совпадают - переименовать всю разметку 313 эпизода.

--- a/validation/episodes/0300-0399/0314.yaml
+++ b/validation/episodes/0300-0399/0314.yaml
@@ -1,0 +1,215 @@
+episode: 314
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Marin_k_a, SPEAKER_01]
+  total_duration_sec: 7900  # ~2:11:40 (оценка по таймстампам)
+  notes: "Выпуск 314 (число Пи) от 10 ноября 2012 года"
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 824
+    replies_count: 242
+    pattern: consecutive
+    first_appearance_sec: 44.83
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: "misha_chernomordikov"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Бобук явно представляет гостя в 57-66 сек:
+        - "Это Миша Черномордиков."
+        - "Его знают почти все, кто занимается интернетом в России."
+        - "Он действительно называется руководитель евангелистов... в российском отделении компании Microsoft."
+
+        SPEAKER_01 отвечает на вопросы про Microsoft сразу после представления (71 сек):
+        - "Нет, у нас в Европе гораздо больше."
+
+        К нему обращаются по имени "Миша" 30+ раз на протяжении всего выпуска.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 402
+    replies_count: 117
+    pattern: consecutive
+    first_appearance_sec: 20.99
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация - уже в справочнике
+      identified_as: "marin_k_a"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Сама представляется в 312.9 сек:
+        - "Меня Маринкой, а Мишу Пете, все правильно."
+
+        Umputun обращается к ней "Ксюш" в 18 сек (возможно оговорка или путаница),
+        но это Марина (бывшая ведущая), которая уже есть в people.yaml.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 15
+    replies_count: 4
+    pattern: scattered
+    first_appearance_sec: 1938.75
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Это реплики, ранее ошибочно приписанные Петру Диденко.
+        Судя по контексту и содержанию (обсуждение Surface, Outlook, Windows RT),
+        эти реплики скорее всего принадлежат гостю Мише Черномордикову (SPEAKER_01),
+        так как он представитель Microsoft и обсуждает их продукты.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "misha_chernomordikov"
+          confidence: 0.8
+          reason: |
+            Контекст реплик связан с Microsoft продуктами:
+            - 1938.75: "Даже в Outlook... А где вы нашли Outlook на Surface, простите?"
+            - 2469.11: "Нет, именно VivaTab RT и Surface, это оба устройства на операционке одной, это Windows RT."
+            Миша как евангелист Microsoft мог бы так говорить.
+
+      voice_task:
+        needed: true
+        reason: "Требуется сравнение голоса с SPEAKER_01 для подтверждения"
+        reference_segment:
+          stime: 1938.75
+          etime: 1942.89
+          text: "Даже в Outlook, вот все-таки кому-то Outlook... А где вы нашли Outlook на Surface, простите?"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 3
+    replies_count: 1
+    pattern: scattered
+    first_appearance_sec: 7467.22
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одиночная реплика, ранее ошибочно приписанная Эльдару Муртазину.
+        По контексту это продолжение рассказа Gray про планшеты в Эфиопии.
+        Gray говорит перед этой репликой, и сразу после.
+        Вероятнее всего это реплика одного из ведущих (Gray или Umputun).
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.6
+          reason: |
+            Контекст: Gray рассказывает про эксперимент с планшетами в Эфиопии,
+            эта реплика является логичным продолжением истории:
+            "Через пять месяцев дети, среди прочего, научились хакать Android."
+            Сразу после этого Gray продолжает: "Ну, что, хорошо."
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Umputun также участвует в обсуждении этой темы"
+
+      voice_task:
+        needed: true
+        reason: "Требуется определить принадлежность реплики"
+        reference_segment:
+          stime: 7467.22
+          etime: 7470.36
+          text: "Через пять месяцев дети, среди прочего, научились хакать Android."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "SPEAKER_01"
+      issue: "Идентифицирован как Миша Черномордиков, но ещё не добавлен в people.yaml"
+    - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+      issue: "Требуется voice comparison для подтверждения принадлежности к SPEAKER_01"
+    - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+      issue: "Требуется voice comparison для определения спикера (вероятно Gray)"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 314
+    from_speaker: "SPEAKER_01"
+    to_speaker: "MishaChernomordikov"
+    confidence: high
+    reason: |
+      Явное представление Бобуком: "Это Миша Черномордиков."
+      Руководитель евангелистов в российском отделении Microsoft.
+      К нему обращаются по имени "Миша" 30+ раз.
+
+  - type: add_to_people_yaml
+    person:
+      id: "misha_chernomordikov"
+      canonical_name: "MishaChernomordikov"
+      aliases: ["Миша Черномордиков", "Черномордиков"]
+      real_name: "Михаил Черномордиков"
+      info: "Руководитель евангелистов Microsoft Russia, выпуск 314"
+    confidence: high
+    reason: "Новый гость, явно представленный в выпуске"
+
+  - type: rename
+    episode: 314
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    to_speaker: "MishaChernomordikov"
+    confidence: medium
+    reason: |
+      Реплики про Microsoft продукты (Surface, Outlook, Windows RT).
+      Требуется voice comparison для подтверждения.
+      Если голос совпадает с SPEAKER_01, переименовать.
+
+  - type: rename
+    episode: 314
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "Gray"
+    confidence: medium
+    reason: |
+      Одиночная реплика внутри рассказа Gray про планшеты в Эфиопии.
+      Требуется voice comparison для подтверждения.
+
+# Дополнительные заметки
+notes: |
+  Эпизод 314 ("число Пи") от 10 ноября 2012 года.
+
+  Участники:
+  - Ведущие: Umputun, Bobuk, Gray
+  - Гости: Марина (Marin_k_a), Миша Черномордиков (SPEAKER_01)
+
+  Особенности:
+  - Umputun в начале обращается к Марине как "Ксюш" (18 сек) - возможно оговорка
+  - Упоминается "Петя" (Пётр Диденко) - но он, похоже, не участвует в этом выпуске
+  - SPEAKER_MISATTRIBUTED метки указывают на ранее отменённые ошибочные присвоения
+
+  Требуется:
+  1. Добавить Мишу Черномордикова в people.yaml
+  2. Переименовать SPEAKER_01 -> MishaChernomordikov
+  3. Voice comparison для SPEAKER_MISATTRIBUTED_PETR и SPEAKER_MISATTRIBUTED_ELDAR

--- a/validation/episodes/0300-0399/0315.yaml
+++ b/validation/episodes/0300-0399/0315.yaml
@@ -1,0 +1,269 @@
+episode: 315
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray, Bobuk]
+  guests_present: [Marin_k_a, PetrDidenko]
+  total_duration_sec: 7580  # Приблизительно по последней реплике
+
+# Комментарий к эпизоду
+# Дата: 17 ноября 2012
+# Umputun в начале объявляет: "из основного состава только наша прекрасная четвертина Ксюша"
+# Gray присоединяется позже (~800s): "К нам присоединился Грей, то есть нас теперь четыре гада"
+# Bobuk имеет всего 3 реплики - скорее всего ошибка распознавания, либо очень краткое участие
+# Гость эпизода: Вадзай (Вадим) - технический администратор Луркмора (размечен как SPEAKER_02)
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 1233
+    replies_count: 306
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: "vadzay"  # Новый гость, нужно добавить в people.yaml
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Прямое представление в начале эпизода (47.5s-55.5s):
+        "Всем добрый день. Зовут меня Вадзай. Я технический администратор небезызвестного сайта Лорк Мор."
+        Umputun подтверждает (55.65s): "Здравствуй, Вадзай"
+        Также говорит (64.8s): "Меня можно просто называть Вадим"
+        Контекст: обсуждение блокировки Луркмора по закону от 1 ноября 2012
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 187
+    replies_count: 71
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Umputun в начале эпизода (15.89s): "Из основного состава только наша прекрасная четвертина Ксюша"
+        SPEAKER_03 отвечает сразу после (22.89s): "Бобок. Ой, Бобок." - узнала Umputun
+        Затем (25.75s): "Так что из основного состава половина" - спорит с Umputun
+        SPEAKER_02 обращается к ней (1667.96s): "Ксения, а ты права"
+        SPEAKER_02 обращается (1749.94s): "Ксения, настоятельная инструкция и блокировка..."
+        Umputun обращается (2378.3s): "Ксения, ты как настоящий русский человек..."
+        Паттерн общения полностью соответствует Ksenks
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 422
+    replies_count: 71
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация - уже корректно размечена
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Марина уже присутствует в people.yaml как бывшая ведущая
+        Первая реплика (24.49s): "Боботун, ты же тоже здесь" - узнаваемое обращение
+        Участвует в обсуждении темы выпуска (199.87s-223.53s) - развёрнутый комментарий
+        Характерный стиль общения - дружеский, неформальный
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "PetrDidenko"
+    total_duration_sec: 145
+    replies_count: 18
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация - уже корректно размечена
+      identified_as: "petr_didenko"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Пётр Диденко указан в people.yaml как разработчик (148 выпусков)
+        Первая реплика (284.13s): "Ну, вообще почти так" - включается в обсуждение закона
+        Реплики связаны с обсуждением Луркмора (1466.08s): "Вместо того, чтобы ловить дилеров..."
+        (1986.57s): "наша сейчас официальная позиция Луркмора, мы сейчас будем обжаловать..."
+        Вероятно, это второй представитель Луркмора, хотя явного представления нет
+        ВАЖНО: возможно это тот же Вадзай, неправильно атрибутированный
+
+      possible_matches:
+        - person_id: "vadzay"
+          confidence: 0.4
+          reason: "Обсуждает Луркмор от первого лица, возможна путаница с SPEAKER_02"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1986.57
+          etime: 1998.4
+          text: "То есть, как бы, например, мы готовы обжаловать, то есть мы сейчас, то есть наша сейчас официальная позиция Луркмора, мы сейчас будем обжаловать сам факт внесения в список."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 12
+    replies_count: 4
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Эльдар Муртазин не был в этом эпизоде (он работает в Яндексе, а Яндекс отказался участвовать).
+        Umputun прямо говорит (338.76s-345.12s): "Яндекс отказался прийти... поэтому мы сегодня без Яндекса"
+        4 короткие реплики разбросаны по эпизоду - скорее всего ошибочная атрибуция
+        Реплики по содержанию не специфичны и могут принадлежать любому участнику
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Реплики появляются после 800s когда Gray присоединился"
+        - person_id: "vadzay"
+          confidence: 0.3
+          reason: "Мог быть неправильно атрибутирован гость эпизода"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2898.02
+          etime: 2902.84
+          text: "И честно вам показывал, что у вас теперь там 3-4 аккаунта, ну, всякое бывает."
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 8
+    replies_count: 7
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Очень короткие реплики (1-3 сек каждая), разбросаны по всему эпизоду
+        Примеры: "Что?", "Ок." - типичные артефакты распознавания
+        Появляются поздно в эпизоде (с 3733s), когда все спикеры уже установлены
+        Суммарно всего 8 секунд - слишком мало для реального участника
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.4
+          reason: "Короткие реакции могли быть от Gray"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Или от Ksenks (SPEAKER_03)"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Gray"
+      issue: |
+        Gray появляется внезапно в 800s без представления в начале.
+        Umputun объявляет присоединение (819.43s): "К нам присоединился Грей"
+        Это нормально - Gray подключился позже.
+
+    - speaker: "Bobuk"
+      issue: |
+        Bobuk имеет только 3 реплики за весь эпизод (5 секунд суммарно).
+        Umputun в начале говорит (345.12s): "ни Бобука, ни Грея нет"
+        Возможно 3 реплики Bobuk - ошибка атрибуции (мог быть Gray или гость)
+
+    - speaker: "PetrDidenko"
+      issue: |
+        PetrDidenko не был представлен в начале эпизода.
+        Говорит о Луркморе от первого лица ("наша официальная позиция Луркмора").
+        Возможно это тот же Вадзай с ошибочной атрибуцией, или второй представитель Луркмора.
+        Требуется voice comparison для проверки.
+
+    - speaker: "SPEAKER_03"
+      issue: |
+        SPEAKER_03 должен быть переименован в Ksenks.
+        71 реплика, 187 сек - существенное участие, контекст однозначно указывает на Ksenks.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 315
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Vadzay"
+    confidence: high
+    reason: |
+      Явное представление в начале эпизода: "Зовут меня Вадзай.
+      Я технический администратор небезызвестного сайта Лорк Мор."
+      Также говорит: "Меня можно просто называть Вадим"
+
+  - type: rename
+    episode: 315
+    from_speaker: "SPEAKER_03"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun обращается к ней как к Ксюше/Ксении многократно.
+      SPEAKER_02 (Вадзай) также обращается к ней "Ксения".
+      Контекст и паттерн общения однозначно указывают на Ksenks.
+
+  - type: rename
+    episode: 315
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "SPEAKER_UNIDENTIFIED"
+    confidence: medium
+    reason: |
+      Эльдар точно не участвовал - Яндекс отказался.
+      Нужен voice comparison для определения реального спикера.
+
+  - type: delete
+    episode: 315
+    from_speaker: "SPEAKER_04"
+    to_speaker: null
+    confidence: medium
+    reason: |
+      7 очень коротких реплик (8 сек суммарно), вероятно артефакты.
+      Можно объединить с ближайшим спикером по контексту.
+
+# Задание для добавления в people.yaml
+new_guest_to_add:
+  id: "vadzay"
+  canonical_name: "Vadzay"
+  aliases: ["Вадзай", "Вадим"]
+  real_name: "Вадим"
+  info: "Технический администратор Луркмора, выпуск 315"

--- a/validation/episodes/0300-0399/0316.yaml
+++ b/validation/episodes/0300-0399/0316.yaml
@@ -1,0 +1,345 @@
+episode: 316
+status: needs_review
+analyzed_at: "2025-01-25"
+
+# Комментарий к эпизоду
+# Дата: 24 ноября 2012
+# Ведущие: Bobuk, Gray
+# Бывшая ведущая: Marin_k_a (Марина)
+# Ведущая: Ksenks (Ксюша) - размечена как SPEAKER_04
+# Umputun - только 2 реплики (359s и 5273s), возможно ошибка атрибуции или минимальное участие
+#
+# Bobuk ведёт выпуск из больницы (22-27s: "я просто в больнице сегодня")
+# Gray подсказывает дату и номер выпуска
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Bobuk, Gray]
+  guests_present: [Marin_k_a]
+  other_present: [SPEAKER_04, SPEAKER_03, SPEAKER_02, SPEAKER_MISATTRIBUTED_ELDAR, SPEAKER_MISATTRIBUTED_LAVALE]
+  umputun_status: "minimal (2 реплики, 2 сек) - требует проверки"
+  total_duration_sec: 7700  # Приблизительно
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 396
+    replies_count: 161
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Прямое обращение в начале эпизода (27.57-29.85s):
+        Bobuk: "Ксюша, скажи, пожалуйста, тебя трогает число 24?"
+        SPEAKER_04 отвечает (32.63s): "Я даже не знаю."
+
+        Повторное обращение (2508.64-2511.17s):
+        Bobuk: "Слушай, Ксюша, скажи, пожалуйста, а у тебя как?"
+        SPEAKER_04 отвечает (2514.21s): "Еще нет, я не щеброт."
+
+        161 реплика, активное участие в обсуждениях - типичный паттерн Ksenks.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 687
+    replies_count: 119
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация - уже корректно размечена
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Марина уже присутствует в people.yaml как бывшая ведущая.
+        Эпизод 316 входит в её период участия (106-538 выпуски).
+        Первая реплика (114.57s): "ОС-10 сейчас так здорово и приятно, привычно звучит."
+        119 реплик, 687 сек - существенное участие, характерный стиль.
+        Говорит "вам с Греем надо поспорить" (2741s) - обращается к ведущим в третьем лице.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 42
+    replies_count: 15
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        15 коротких реплик, разбросанных по всему эпизоду.
+        SPEAKER_03 и SPEAKER_04 (Ksenks) говорят с разницей в 3-5 секунд:
+        - SPEAKER_03 @ 574s, SPEAKER_04 @ 579s (5s разница)
+        - SPEAKER_03 @ 3258s, SPEAKER_04 @ 3255s (3s разница)
+
+        Скорее всего это ошибка распознавания голоса Ksenks.
+        Система в некоторых моментах приняла её за другого спикера.
+
+        Однако есть странная реплика (7326.2s): "Алиса, ты меня не путай" -
+        обращение к Алисе не характерно для контекста.
+        Требуется voice comparison для окончательного решения.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: |
+            Реплики перемежаются с SPEAKER_04 (Ksenks) с минимальной задержкой.
+            На 5531s отвечает на вопрос "на Ксюшу не перевесить" - вероятно Ксюша.
+            Bobuk говорит "Как с вами, девочками, сложно" перед репликой SPEAKER_03.
+        - person_id: "marin_k_a"
+          confidence: 0.2
+          reason: |
+            В эпизоде две девушки (Ксюша и Марина).
+            Однако Marin_k_a уже размечена отдельно с 119 репликами.
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5531.26
+          etime: 5537.58
+          text: "Ну а зачем мне такое перевешивать? У меня проблема питания еще остро стоит."
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 2
+    replies_count: 4
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        4 очень короткие реплики (суммарно 2 сек).
+        Все реплики - междометия: "Угу." (3743s, 4208s) и "Ха-ха." (6873s x2).
+        Типичные артефакты распознавания или неправильная атрибуция реакций.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.4
+          reason: "Короткие реакции могли быть от Gray"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Или от Bobuk"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 7
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Лаваль не участвовала в этом эпизоде (она была ведущей в выпусках 109-462).
+        Только 2 реплики (1610s и 3336s) по 3-4 сек каждая.
+        Это ошибочная атрибуция - реплики должны принадлежать другому участнику.
+        Пометка MISATTRIBUTED уже указывает на отменённое присвоение.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Мог быть женский голос Ksenks"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Или Marin_k_a"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 6
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Эльдар Муртазин не участвовал в этом эпизоде.
+        Только 3 короткие реплики (646s, 2134s, и ещё одна).
+        Пометка MISATTRIBUTED уже указывает на отменённое присвоение.
+
+        Реплика 2134s: "У меня карта Одессы русская, прямо сейчас" -
+        не характерна для Эльдара в контексте обсуждения.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.4
+          reason: "Мог быть Gray"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Или Bobuk"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Umputun"
+    total_duration_sec: 2
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: false  # Неясно, требуется проверка
+      error_reason: null
+
+      # Анализ
+      identified_as: "umputun"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Только 2 реплики за весь эпизод:
+        1. 359.14-359.56s: "Конечно." (после реплики Bobuk "Это будет совершенно уникальный выпуск")
+        2. 5273.01-5274.13s: "Нет, смотри."
+
+        Это очень мало для Umputun (обычно сотни реплик).
+        Возможные объяснения:
+        - Umputun действительно минимально участвовал (был занят)
+        - Ошибка атрибуции (реплики другого ведущего)
+        - Bobuk вёл выпуск из больницы, Umputun мог отсутствовать
+
+        В начале Bobuk не упоминает Umputun среди участников.
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Реплики могли быть неправильно атрибутированы от Gray"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5273.01
+          etime: 5274.13
+          text: "Нет, смотри."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Umputun"
+      issue: |
+        Umputun не был представлен в начале эпизода.
+        Bobuk упоминает только Gray ("подсказал мне Грей") и обращается к Ксюше.
+        Всего 2 реплики Umputun - аномально мало.
+        Требуется проверка: участвовал ли Umputun или это ошибка атрибуции.
+
+    - speaker: "SPEAKER_04"
+      issue: |
+        SPEAKER_04 должен быть переименован в Ksenks.
+        Прямые обращения "Ксюша" от Bobuk подтверждают идентификацию.
+        161 реплика, 396 сек - существенное участие.
+
+    - speaker: "SPEAKER_03"
+      issue: |
+        15 коротких реплик, вероятно ошибка распознавания Ksenks.
+        Говорит почти одновременно с SPEAKER_04 (3-5 сек разница).
+        Требуется voice comparison для подтверждения.
+
+    - speaker: "Marin_k_a"
+      issue: |
+        Marin_k_a корректно размечена как бывшая ведущая Марина.
+        В этом эпизоде две девушки: Ксюша (Ksenks) и Марина.
+        Реплика (2741s): "вам с Греем надо поспорить" подтверждает, что это не Gray.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 316
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Прямые обращения от Bobuk: "Ксюша, скажи, пожалуйста" (27s, 2508s).
+      SPEAKER_04 отвечает на эти обращения.
+      161 реплика - активное участие в выпуске.
+
+  - type: rename
+    episode: 316
+    from_speaker: "SPEAKER_03"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      Вероятно ошибка распознавания голоса Ksenks.
+      Говорит с минимальной задержкой относительно SPEAKER_04.
+      На 5531s отвечает на вопрос о Ксюше.
+      Требуется voice comparison для полной уверенности.
+
+  - type: merge
+    episode: 316
+    from_speaker: "SPEAKER_02"
+    to_speaker: "NEAREST"
+    confidence: medium
+    reason: |
+      4 очень короткие реплики ("Угу", "Ха-ха") - артефакты.
+      Можно объединить с ближайшим спикером по контексту.
+
+  - type: delete_or_reassign
+    episode: 316
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "SPEAKER_UNIDENTIFIED"
+    confidence: medium
+    reason: |
+      Лаваль точно не участвовала в этом эпизоде.
+      2 реплики требуют переатрибуции на основе voice comparison.
+
+  - type: delete_or_reassign
+    episode: 316
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "SPEAKER_UNIDENTIFIED"
+    confidence: medium
+    reason: |
+      Эльдар точно не участвовал в этом эпизоде.
+      3 реплики требуют переатрибуции на основе voice comparison.
+
+# Основные выводы
+summary: |
+  Эпизод 316 (24 ноября 2012) - выпуск с двумя девушками: Ксюша (Ksenks) и Марина (Marin_k_a).
+
+  Основные находки:
+  1. SPEAKER_04 = Ksenks (высокая уверенность, прямые обращения "Ксюша")
+  2. Marin_k_a - корректно размечена
+  3. SPEAKER_03 - вероятно ошибка распознавания Ksenks (говорит с ней почти одновременно)
+  4. Umputun - аномально мало реплик (2), требует проверки участия
+  5. SPEAKER_02, SPEAKER_MISATTRIBUTED_* - артефакты/ошибки, требуют переатрибуции
+
+  Статус: needs_review (требуется voice comparison для SPEAKER_03 и проверка участия Umputun)

--- a/validation/episodes/0300-0399/0317.yaml
+++ b/validation/episodes/0300-0399/0317.yaml
@@ -1,0 +1,177 @@
+episode: 317
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [Marin_k_a]
+  absent_hosts: [Gray]  # "тот из нас, кто самый менее гик, решил просто не приходить"
+  total_duration_sec: 8100  # ~2 часа 15 минут
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 467
+    replies_count: 183
+    first_reply_at: 35.47
+    pattern: consecutive  # много реплик, активное участие в диалогах
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Прямое доказательство: на 33-35 секундах эпизода
+        Umputun: "Вот Ксюша может. Ксюша, ты можешь?" (33.44-34.12s)
+        SPEAKER_00: "Да, я могу." (35.47-36.15s)
+
+        Дополнительно: к "Ксюше" обращаются 25+ раз в течение выпуска,
+        и SPEAKER_00 активно участвует в диалогах.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 408
+    replies_count: 82
+    first_reply_at: 36.19
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Marin_k_a уже идентифицирована в people.yaml как бывшая ведущая
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Марина (Marin_k_a) — известная бывшая ведущая подкаста.
+        В этом выпуске присутствует вместе с Ksenks.
+        Имя "Марина" не упоминается явно в транскрипте, но голос
+        распознан системой как отдельный от SPEAKER_00 (Ksenks).
+        Реплики содержательные, участвует в обсуждении технических тем.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 3
+    replies_count: 1
+    first_reply_at: 7676.57
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика "Ближайшие полгода, год?" (7676.57-7679.75s)
+        идёт сразу после вопроса Marin_k_a "И как скоро, в какой перспективе?"
+        Контекст: обсуждение цен на Amazon хранилища.
+        Скорее всего это продолжение вопроса Marin_k_a или ошибка сегментации.
+        Ранее была ошибочно присвоена Петру Диденко, но отменена.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.7
+          reason: "Продолжение её предыдущего вопроса о перспективах"
+        - person_id: "ksenks"
+          confidence: 0.2
+          reason: "Может быть голос Ksenks неправильно распознан"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 7676.57
+          etime: 7679.75
+          text: "Ближайшие полгода, год?"
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 1
+    replies_count: 2
+    first_reply_at: 7236.78
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Две очень короткие реплики:
+        1. "Ха-ха-ха." (7236.78-7237.08s) — смех после шутки Bobuk про "шлюхокот"
+        2. "Компилятор?" (7887.47-7888.41s) — переспрос после вопроса Umputun
+        Обе <1 сек, это артефакты автоматического распознавания голосов.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Обе реплики могут принадлежать Bobuk (реакции на его же контекст)"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Женский смех мог быть неправильно распознан"
+
+      voice_task:
+        needed: false
+        reference_segment: null  # слишком короткие для voice comparison
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_00"
+      issue: |
+        SPEAKER_00 — это Ksenks с высокой уверенностью.
+        Нужно переименовать в Ksenks.
+    - speaker: "Marin_k_a"
+      issue: |
+        Марина присутствует в выпуске, но её участие не было явно анонсировано
+        в начале ("полный состав для гиковских выпусков"). Возможно, она
+        участвовала как постоянная со-ведущая и не требовала представления.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 317
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Прямая идентификация: ответ "Да, я могу" на вопрос "Ксюша, ты можешь?"
+      183 реплики, 467 секунд — значительное участие в выпуске.
+
+  - type: merge_or_delete
+    episode: 317
+    from_speaker: "SPEAKER_03"
+    to_speaker: null  # рекомендуется удалить или смержить в соседние реплики
+    confidence: medium
+    reason: |
+      Ошибка распознавания: 2 реплики <1 сек каждая.
+      "Ха-ха-ха" — смех, "Компилятор?" — переспрос.
+      Можно удалить или присоединить к соседним репликам Bobuk.
+
+  - type: needs_voice_comparison
+    episode: 317
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    to_speaker: null
+    confidence: low
+    reason: |
+      Одна реплика 3 сек. Может быть Marin_k_a (продолжение вопроса)
+      или ошибка распознавания. Требует voice comparison.

--- a/validation/episodes/0300-0399/0318.yaml
+++ b/validation/episodes/0300-0399/0318.yaml
@@ -1,0 +1,194 @@
+episode: 318
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray]
+  guests_present: [Marin_k_a, EldarMurtazin]
+  total_duration_sec: 7377  # ~2h 3m
+
+# Важное примечание
+notes: |
+  В начале эпизода (34.81s) Umputun говорит: "Бобука сегодня нет, но подкаст есть".
+  Однако в транскрипте есть 1 реплика от Bobuk (2269.7s).
+  Это явная ошибка разметки - Bobuk отсутствует в этом выпуске.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1354
+    replies_count: 303
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        В начале эпизода (1.14s) Umputun говорит: "...о чем мне не преминули одновременно
+        сообщить Грей и Ксюша, она же Оксана". Далее Marin_k_a активно участвует в диалоге
+        с первых секунд (15.55s). В справочнике people.yaml Marin_k_a - бывшая ведущая Марина.
+        Примечание: "Ксюша/Оксана" - это её альтернативные имена (не Ksenks).
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 151
+    replies_count: 26
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Umputun представляет его как "Игорь" (4067.19s): "Пришел к нам Игорь, говорит,
+        про вас знает все...". Также упоминается имя "Виталий" (4023.08s): "Я как раз
+        Виталию... Виталию звоним". Это слушатель, позвонивший по скайпу рассказать
+        про антивирус Avast. Все его реплики сконцентрированы в одном сегменте
+        (4074-4358s) и касаются технических деталей Avast.
+
+      possible_matches:
+        - person_id: "listener_igor"
+          confidence: 0.7
+          reason: "Umputun называет его 'Игорь' в 4067s"
+        - person_id: "listener_vitaliy"
+          confidence: 0.3
+          reason: "Ранее упоминался 'Виталий', но он не ответил на звонок"
+
+      voice_task:
+        needed: false
+        reason: "Это случайный слушатель-звонящий, не постоянный гость. Идентификация не критична."
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 101
+    replies_count: 18
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      identified_as: "eldar_murtazin"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        EldarMurtazin - известный мобильный аналитик, регулярный гость подкаста.
+        Его реплики разбросаны по эпизоду (3992s-8037s), он активно участвует
+        в обсуждении технических тем. Характерный стиль комментариев подтверждает
+        идентификацию. В people.yaml есть запись eldar_murtazin.
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 11
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Название спикера указывает на "misattributed" (ошибочное присвоение).
+        Все 3 реплики идут сразу после реплик Marin_k_a и продолжают её мысль:
+        - 693.91s: "Но я не думаю, что так все будет." (после Marin_k_a о Google+)
+        - 1014.81s: "Все так делают, так что, ну, нормально, молодцы." (после Marin_k_a)
+        - 5159.34s: "И потом оказалось, что тот, который ушел, он важнее..." (продолжение мысли Marin_k_a об Apple)
+        Это явно реплики Marin_k_a, ошибочно размеченные.
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: "Все 3 реплики логически продолжают предшествующие реплики Marin_k_a"
+
+      voice_task:
+        needed: false
+
+  - speaker: "Bobuk"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        В начале эпизода (34.81s) Umputun явно говорит: "Бобука сегодня нет, но подкаст есть".
+        Однако в транскрипте есть 1 реплика Bobuk (2269.7s): "Вообще нет уже баров никаких".
+        Контекст: обсуждение Яндекс.Бара, до этого говорит Marin_k_a, после - Gray.
+        Реплика короткая (2 сек), по смыслу может быть сказана Gray или Marin_k_a.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Bobuk официально отсутствует в этом выпуске"
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.6
+          reason: "Gray сразу после продолжает тему: 'Ну, то есть Яндекс.Бар прекращен'"
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "Marin_k_a говорит прямо перед этой репликой"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2269.7
+          etime: 2271.96
+          text: "Вообще нет уже баров никаких."
+        compare_with:
+          - speaker: "Gray"
+            segment:
+              stime: 2272.0
+              etime: 2278.2
+              text: "Ну, то есть Яндекс.Бар прекращен. Сейчас есть элементы."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Bobuk"
+      issue: |
+        Bobuk размечен с 1 репликой, но в начале выпуска явно сказано что его нет.
+        Требуется переразметка на Gray или Marin_k_a.
+
+    - speaker: "SPEAKER_00"
+      issue: |
+        Слушатель-звонящий (предположительно Игорь) не добавлен в people.yaml.
+        Можно оставить как есть (случайный звонок) или создать запись listener_ep318_igor.
+
+    - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+      issue: |
+        3 реплики ошибочно размечены. Следует переименовать в Marin_k_a.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 318
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Marin_k_a"
+    confidence: high
+    reason: |
+      Все 3 реплики SPEAKER_MISATTRIBUTED_LAVALE логически продолжают
+      предшествующие реплики Marin_k_a. Контекстный анализ однозначен.
+
+  - type: rename
+    episode: 318
+    from_speaker: "Bobuk"
+    to_speaker: "Gray"
+    confidence: medium
+    reason: |
+      Bobuk официально отсутствует в выпуске 318 (подтверждено в начале эпизода).
+      Реплика "Вообще нет уже баров никаких" по контексту скорее принадлежит Gray,
+      который сразу продолжает тему. Требуется voice comparison для подтверждения.
+
+  - type: rename
+    episode: 318
+    from_speaker: "SPEAKER_00"
+    to_speaker: "ListenerIgor"
+    confidence: medium
+    reason: |
+      Umputun называет позвонившего слушателя "Игорь". Можно оставить SPEAKER_00
+      или переименовать для читаемости. Это не регулярный гость.

--- a/validation/episodes/0300-0399/0319.yaml
+++ b/validation/episodes/0300-0399/0319.yaml
@@ -1,0 +1,237 @@
+episode: 319
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [SPEAKER_00, Marin_k_a]
+  total_duration_sec: 7286
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 869
+    replies_count: 205
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: null
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        На 135.56s Umputun: "Дорогой Андрей, надо было сказать, я фанат шоу, мы бы тебя быстрее пустили."
+        На 142.82s: "Прав ли я, Андрей?"
+        На 20602s: "Андрей, спасибо, что пришел, рассказал нам всякие глупости про всякие глупые Apple."
+        SPEAKER_00 сам представился: "Я, поскольку сам инженер, закончил радиотехнические институции"
+        Гость по имени Андрей, инженер, любитель плов и техники Apple, уважает Возняка больше Джобса.
+
+      possible_matches:
+        - person_id: "andrey_guest_319"
+          confidence: 0.95
+          reason: "Явное представление по имени Андрей, полноценное участие в выпуске (869 сек речи)"
+
+      voice_task:
+        needed: true
+        reason: "Для идентификации гостя в других выпусках"
+        reference_segment:
+          stime: 1537.92
+          etime: 1556.2
+          text: "Господа, кстати, вы заметили, что когда выпускали приложения Google, которые были в период конфронтации с компанией Apple, они выпускались, как везде писали, на черном фоне."
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 803
+    replies_count: 217
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # ВАЖНО: несоответствие имени!
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        К этому спикеру обращаются как "Ксюша" минимум 20 раз по всему выпуску:
+        - "Кроме Ксюши" (1387)
+        - "Да, нет, Ксюша, конечно, ей 17" (1396)
+        - "Итак, Ксюша, ты ведь к тарелочкам самая близкая из нас из всех, правильно?" (2134)
+        - "Ну, Ксюш, ну, пойми, что XR они с горячей заменой" (9424)
+
+        Также обращаются как "Оксана" (~10 раз), что может быть прозвищем или полным именем Ксении.
+        Marin_k_a в people.yaml = Марина, но к спикеру НЕ обращаются как Марина ни разу.
+
+        ВЫВОД: Спикер неправильно размечен. Это Ksenks (Ксения), не Marin_k_a (Марина).
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.95
+          reason: "К спикеру обращаются 'Ксюша' и 'Оксана' на протяжении всего выпуска"
+
+      voice_task:
+        needed: false
+        reason: "Идентификация не требуется - это известная ведущая Ksenks"
+
+  - speaker: "Gray"
+    total_duration_sec: 4
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Всего 1 реплика длительностью 4 секунды.
+        Gray не упоминается в начале выпуска среди участников.
+        Umputun говорит "нас четверо" - это Umputun, Bobuk, Ksenks и гость Андрей.
+        Реплика "А новое приложение как-то достаточно радостно выглядит" идёт после SPEAKER_00.
+        Вероятно это ошибка распознавания - реплика принадлежит одному из участников (Bobuk, Umputun, или SPEAKER_00).
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: true
+        reason: "Проверить, кому принадлежит эта реплика"
+        reference_segment:
+          stime: 1556.34
+          etime: 1559.97
+          text: "А новое приложение как-то достаточно радостно выглядит."
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 5
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        3 очень короткие реплики (суммарно 5 секунд) разбросаны по выпуску:
+        - 2802s: "Нет, главное, что... Конечно." (3.3s)
+        - 5509s: "Ну, запустили недавно, да." (1.3s)
+        - 8040s: "Пока." (0.7s, прощание в конце)
+
+        Это типичные фразы-заполнители, скорее всего ошибочно приписаны отдельному спикеру.
+        Вероятно принадлежат одному из ведущих (Umputun, Bobuk) или гостю Андрею.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reason: "Реплики слишком короткие для voice matching"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 15
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Имя спикера указывает на ошибочную атрибуцию к Эльдару Муртазину.
+        3 реплики:
+        - 3608s: "Не, ну, Ксюш, ну, пойми, что XR они с горячей заменой хотя бы..." (12.9s)
+        - 4216s: "Это же... Как ее зовут?" (1.3s)
+        - 5410s: "Или ты сейчас про что?" (1.0s)
+
+        Первая реплика обращается к "Ксюш" - так говорят ведущие.
+        Также в реплике упоминается "Андрей, я тебе расскажу" - обращение к гостю.
+        Это явно один из ведущих (Umputun или Bobuk), не Эльдар.
+
+      identified_as: null
+      identification_method: "context"
+      confidence: medium
+      evidence: "Обращение 'Ксюш' и 'Андрей' указывает на ведущего, знающего участников выпуска"
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.6
+          reason: "Umputun часто обращается к участникам по именам"
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Bobuk также мог произнести эти реплики"
+
+      voice_task:
+        needed: true
+        reason: "Определить, кому принадлежат реплики (Umputun или Bobuk)"
+        reference_segment:
+          stime: 3608.47
+          etime: 3621.41
+          text: "Не, ну, Ксюш, ну, пойми, что XR они с горячей заменой хотя бы, а вот у тебя вылетает один диск или сейчас там уже диски... Андрей, я тебе расскажу, как поступаешь."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Gray"
+      issue: "Gray не представлен в начале выпуска, но есть 1 реплика - вероятно ошибка распознавания"
+    - speaker: "Marin_k_a"
+      issue: |
+        КРИТИЧЕСКАЯ ОШИБКА РАЗМЕТКИ: спикер помечен как Marin_k_a (Марина),
+        но к нему обращаются как 'Ксюша' и 'Оксана'.
+        Это Ksenks (Ксения), не Marin_k_a.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 319
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "К спикеру обращаются 'Ксюша' (~20 раз) и 'Оксана' (~10 раз), но никогда 'Марина'"
+
+  - type: rename
+    episode: 319
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Andrey_Guest_319"
+    confidence: high
+    reason: "Гость представлен по имени Андрей, инженер с радиотехническим образованием"
+
+  - type: delete_speaker
+    episode: 319
+    speaker: "Gray"
+    confidence: medium
+    reason: "1 реплика 4 сек, Gray не упоминается в начале выпуска, вероятно ошибка распознавания"
+
+  - type: merge_into
+    episode: 319
+    from_speaker: "SPEAKER_04"
+    merge_strategy: "voice_match_required"
+    confidence: low
+    reason: "3 короткие реплики (5 сек суммарно), ошибки распознавания"
+
+  - type: merge_into
+    episode: 319
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    merge_strategy: "voice_match_required"
+    confidence: medium
+    reason: "Ошибочная атрибуция к Эльдару, реплики принадлежат одному из ведущих"
+
+# Дополнительные заметки
+notes: |
+  1. Эпизод 319 (15 декабря 2012):
+     - Umputun (ведущий)
+     - Bobuk (ведущий)
+     - Ksenks/Ксюша/Оксана (неправильно размечена как Marin_k_a)
+     - Гость Андрей (инженер, любитель Apple)
+
+  2. Gray НЕ участвовал в этом выпуске - 1 реплика это ошибка.
+
+  3. SPEAKER_MISATTRIBUTED_ELDAR - это маркер ранее ошибочно приписанных Эльдару реплик,
+     которые на самом деле принадлежат кому-то из ведущих.
+
+  4. Фраза "У меня, Маруся, у меня, Оксана" может указывать на то, что к Ksenks
+     обращаются разными именами (Маруся, Оксана, Ксюша) - возможно это шутливые прозвища.

--- a/validation/episodes/0300-0399/0320.yaml
+++ b/validation/episodes/0300-0399/0320.yaml
@@ -1,0 +1,167 @@
+episode: 320
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7094
+  note: "Ksenks присутствует (26 упоминаний по имени), но размечена как SPEAKER_00"
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 499
+    replies_count: 199
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. Umputun обращается: "Ксюша, а ты как относишься к людям..." (239s) — сразу после отвечает SPEAKER_00
+        2. Bobuk говорит: "у нас еще где-то виртуально обитает Ксюша" (99s) — и SPEAKER_00 появляется в 253s
+        3. SPEAKER_00 говорит про CocoaPods и Objective-C (2053s), а позже: "Ксюша, если тебе Objective-C нравится"
+        4. Всего 26 упоминаний "Ксюша/Ксюш" в тексте, но нет спикера Ksenks
+        5. SPEAKER_00 ведет диалог с Marin_k_a (421s) — это разные люди
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment:
+          stime: 2053.1
+          etime: 2087.5
+          text: "Какоаподс — это некий репозиторий для Objective-C... Это как порты?"
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 3
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. Появляется после "Ксюша, у меня к тебе вопрос" (1788s) — отвечает "Инстаграм?" (1799s)
+        2. Вторая реплика "В Vimeo сам" (4107s) — короткая ремарка в обсуждении
+        3. Это та же Ксюша, что и SPEAKER_00 — просто другой ID от автоматической разметки
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 0
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Одна короткая реплика 'Пока' (7741s) в момент прощания. Скорее всего ошибка распознавания — кто-то из участников (вероятно Ksenks или Marin_k_a) сказал 'Пока' после Bobuk."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Ksenks присутствует в эфире, могла прощаться"
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "Marin_k_a тоже присутствует, её последняя реплика в 7714s"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 609
+    replies_count: 114
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Уже правильно идентифицирована в cleaning/people.yaml как Марина (бывшая ведущая).
+        Активно участвует в обсуждении с 347s до конца выпуска.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_99"
+    total_duration_sec: 0
+    replies_count: 6
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Специальный спикер для аудио-артефактов, джинглов. Игнорировать."
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "SPEAKER_00"
+      issue: "Ksenks размечена как SPEAKER_00, требуется переименование"
+    - speaker: "SPEAKER_04"
+      issue: "Ещё один ID для Ksenks, требуется переименование"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 320
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun и Bobuk многократно обращаются к "Ксюша" (26 раз),
+      после чего отвечает SPEAKER_00. Контекст про Objective-C и CocoaPods
+      совпадает с известной экспертизой Ksenks.
+
+  - type: rename
+    episode: 320
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Появляется на прямой вопрос к Ксюше ("Ксюша, у меня к тебе вопрос" → "Инстаграм?").
+      Это тот же человек, что SPEAKER_00, просто другой ID автоматической разметки.
+
+  - type: delete
+    episode: 320
+    from_speaker: "SPEAKER_03"
+    to_speaker: null
+    confidence: medium
+    reason: |
+      Одна реплика "Пока" в момент прощания. Слишком короткая для идентификации,
+      можно оставить или объединить с предыдущим спикером (Bobuk).

--- a/validation/episodes/0300-0399/0321.yaml
+++ b/validation/episodes/0300-0399/0321.yaml
@@ -1,0 +1,142 @@
+episode: 321
+status: has_tasks
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray, Ksenks]
+  notes: |
+    Ksenks присутствует, но ошибочно размечена как Marin_k_a и SPEAKER_03.
+    Gray появился на 871s (подтверждено фразой Umputun: "к нам пришел Грей").
+  total_duration_sec: ~2840
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 107
+    replies_count: 21
+    pattern: consecutive
+    first_reply_sec: 90
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. Umputun в 83-89s говорит: "Вот Ксюша так себя не ведет. Она приличная
+           девушка и не стала выкаблучиваться перед тем, как прийти на этот выпуск."
+        2. Сразу после (90s) Marin_k_a отвечает: "Ну у меня просто не получается
+           выкаблучиваться так классно, как у Бабука."
+        3. Umputun в 865s говорит: "Дайте Ксюше слово, мужланы, говорят нам в чате"
+        4. Ksenks вообще отсутствует в разметке этого эпизода.
+        5. Marin_k_a в people.yaml — это Марина (бывшая ведущая), но здесь
+           контекст однозначно указывает на Ксению (Ksenks).
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 95
+    replies_count: 49
+    pattern: scattered
+    first_reply_sec: 16
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. SPEAKER_03 появляется сразу после обращений к Ксюше:
+           - 174s: после "Ксюша нам доложит" (Umputun) → SPEAKER_03 отвечает
+           - 873s: сразу после появления Gray, когда Umputun просил дать слово Ксюше
+        2. SPEAKER_03 и Marin_k_a чередуются в одних диалогах (строки 5479-5518),
+           говоря как один собеседник — это разбиение одного голоса на два спикера.
+        3. Тематика реплик SPEAKER_03 (техническая: Chromebook, IP-адреса)
+           соответствует стилю Ksenks.
+        4. Реплики в начале (16s: "212-85-06-321", "Да, давай") — это короткие
+           подсказки/реакции в диалоге с Umputun, типичные для со-ведущего.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 0
+    replies_count: 1
+    pattern: scattered
+    first_reply_sec: 1718
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика — короткое "Угу" длительностью <0.2 сек (1718.17-1718.31s).
+        Это типичная ошибка распознавания: слишком короткий сегмент, односложная
+        реакция, не принадлежит отдельному спикеру.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.6
+          reason: "Реплика в контексте монолога Bobuk о Linux/играх"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Может быть реакция ведущего"
+
+      voice_task:
+        needed: false
+        reason: "Сегмент слишком короткий для voice comparison"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Ksenks"
+      issue: |
+        Ksenks отсутствует в разметке, хотя явно присутствует в эпизоде.
+        Все её реплики ошибочно размечены как Marin_k_a и SPEAKER_03.
+    - speaker: "Marin_k_a"
+      issue: |
+        Marin_k_a (Марина) не должна быть в этом эпизоде — это ошибка разметки.
+        Реальный спикер — Ksenks (Ксения).
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 321
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun обращается к "Ксюша", и Marin_k_a отвечает. Контекст однозначно
+      указывает на Ksenks. Ksenks отсутствует в разметке этого эпизода.
+
+  - type: rename
+    episode: 321
+    from_speaker: "SPEAKER_03"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      SPEAKER_03 появляется после обращений к Ксюше, чередуется с Marin_k_a
+      в диалогах как один собеседник. Это разбиение голоса Ksenks на два спикера.
+
+  - type: delete_or_merge
+    episode: 321
+    from_speaker: "SPEAKER_04"
+    to_speaker: null
+    confidence: medium
+    reason: |
+      Единственная реплика "Угу" (<0.2 сек) — артефакт распознавания.
+      Можно удалить или объединить с предыдущим спикером (Bobuk).

--- a/validation/episodes/0300-0399/0322.yaml
+++ b/validation/episodes/0300-0399/0322.yaml
@@ -1,0 +1,186 @@
+episode: 322
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 6432  # ~1h47m эфира
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 239
+    replies_count: 104
+    pattern: consecutive  # появляется группами, участвует в диалогах
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. В начале выпуска (51-62s) Umputun обращается к "Ксюше",
+           SPEAKER_00 сразу отвечает "Хорошо, я прослежу"
+        2. Реплика в 1007s "Так что заберите свою Оксану и обратно" -
+           шутка про альтернативное имя (Umputun говорил "буду называть Оксаной")
+        3. В транскрипте 0 реплик Ksenks, хотя она явно участвует в выпуске
+        4. Характер реплик соответствует со-ведущей (вопросы, комментарии)
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 551
+    replies_count: 95
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Marin_k_a уже в справочнике people.yaml как бывшая ведущая Марина.
+        Umputun в начале (58-62s) говорит "Маринкой почти не буду [называть]" -
+        подтверждает присутствие Марины в выпуске.
+        Реплики осмысленные, участие в диалогах.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 6
+    replies_count: 4
+    pattern: scattered  # разбросаны по выпуску
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие изолированные фразы (1-3 сек), разбросанные по выпуску.
+        Эльдар Муртазин не был гостем этого выпуска (не представлен, не упомянут).
+        Вероятно ошибки автоматического распознавания других ведущих.
+        Маркер MISATTRIBUTED указывает, что это уже было выявлено ранее.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.4
+          reason: "Короткие реплики, стиль похож на Umputun"
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Может быть ошибка распознавания голоса Bobuk"
+
+      voice_task:
+        needed: false  # уже помечено как misattributed
+        reference_segment: null
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 3
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Только 2 коротких междометия: "Черт" (750s) и "Угу" (4860s).
+        Суммарно 3 секунды. Типичные ошибки сегментации/распознавания.
+        Скорее всего реплики кого-то из ведущих.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Междометия в стиле Bobuk"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Может быть Gray"
+
+      voice_task:
+        needed: false  # слишком короткие для идентификации
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одна реплика 2 сек: "То есть, в принципе, лет 10 назад" (482s).
+        Lavale не была гостем этого выпуска.
+        Маркер MISATTRIBUTED указывает, что это уже было выявлено ранее.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Женский голос, может быть Марина"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Или Ksenks"
+
+      voice_task:
+        needed: false  # уже помечено как misattributed
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "SPEAKER_00"
+      issue: |
+        SPEAKER_00 должен быть переименован в Ksenks.
+        В начале выпуска Ksenks представлена, но все её реплики
+        записаны как SPEAKER_00.
+    - speaker: "Ksenks"
+      issue: |
+        В транскрипте 0 реплик Ksenks, хотя она участвует в выпуске.
+        Все реплики ошибочно размечены как SPEAKER_00.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 322
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      SPEAKER_00 это Ksenks. Доказательства:
+      1. Umputun представляет Ксюшу в начале, SPEAKER_00 отвечает
+      2. Шутка про "Оксану" (альтернативное имя Ksenks)
+      3. 0 реплик Ksenks в транскрипте при явном участии
+
+  - type: delete_or_reassign
+    episode: 322
+    from_speaker: "SPEAKER_01"
+    to_speaker: null  # требует ручной проверки
+    confidence: low
+    reason: |
+      Только 2 междометия (3 сек). Недостаточно данных для
+      автоматического переименования. Рекомендуется ручная проверка
+      или удаление как шума.

--- a/validation/episodes/0300-0399/0323.yaml
+++ b/validation/episodes/0300-0399/0323.yaml
@@ -1,0 +1,205 @@
+episode: 323
+status: has_tasks
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray, Ksenks]
+  guests_present: []
+  total_duration_sec: 6495
+  notes: >
+    Ksenks ошибочно размечена как Marin_k_a. Это подтверждено множеством
+    обращений Umputun по имени "Ксюша" и "Оксана" к спикеру Marin_k_a.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 788
+    replies_count: 189
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Ошибочная атрибуция. Marin_k_a в этом эпизоде - это Ксения (Ksenks).
+        Доказательства:
+        1) В начале Umputun представляет: "Оксана, она же Ксения" (21-26s)
+        2) Umputun обращается "Спой, Оксана" (94s) - отвечает Marin_k_a (100s)
+        3) Umputun спрашивает "Помнишь, Ксюша?" (861s) - отвечает Marin_k_a (862s)
+        4) Umputun говорит "Про грузовики автомобилей, Оксана?" (869s) - отвечает Marin_k_a (874s)
+        5) Нет ни одной реплики Ksenks в эпизоде, хотя она объявлена в начале
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: >
+        Umputun многократно обращается к Marin_k_a как "Ксюша" и "Оксана",
+        в начале явно объявляет Ксению участницей, при этом ни одной реплики
+        с автором Ksenks нет.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 26
+    replies_count: 10
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Это отменённые присвоения - кто-то ранее ошибочно пометил эти реплики
+        как Эльдара Муртазина, но затем отменил. Эти реплики принадлежат одному
+        из ведущих (скорее всего Bobuk или Gray) - требуется voice comparison.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: >
+        Реплики разрознены по всему эпизоду. Содержание типичное для обсуждения
+        ведущими (iPad mini, Basecamp, МСМ). Эльдар не был объявлен гостем.
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.6
+          reason: "Контекст диалога - реплики между репликами Bobuk"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Альтернативный кандидат"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2821.66
+          etime: 2828.81
+          text: "Хотя, должен честно сказать, что Basecamp не очень клево работает с рассылкой. Ну, с почтой вообще."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 5
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Единственная короткая реплика между двумя репликами Marin_k_a (которая
+        на самом деле Ksenks) и Bobuk. Скорее всего это продолжение мысли Ксении
+        (Marin_k_a/Ksenks).
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: >
+        Реплика на 6081s "Ну то есть очевидно, что Java была бы выше..." идёт
+        сразу после реплик Marin_k_a и логически продолжает её мысль об
+        open-source статистике языков программирования.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: "Продолжение диалога Marin_k_a (которая = Ksenks)"
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 3
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Короткая реплика между Gray и Marin_k_a. Пётр Диденко не был объявлен
+        гостем этого выпуска.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: >
+        Реплика на 2569s "Да нет, это штука для общения по e-mail" - одиночная
+        в контексте обсуждения Basecamp Breeze.
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Предшествующая и близкая по теме реплика Gray"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Следующая реплика от Marin_k_a/Ksenks"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2569.15
+          etime: 2572.32
+          text: "Да нет, это штука для общения по e-mail."
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Единственная односложная реплика "скачанных пиратских" (1.4 сек) между
+        двумя репликами Gray. Явная ошибка распознавания - это часть фразы Gray.
+
+      identified_as: "gray"
+      identification_method: "context"
+      confidence: high
+      evidence: >
+        Gray говорит "такого количества скачетных МПТишек" (2225-2229s),
+        затем SPEAKER_05 "скачанных пиратских" (2230s), затем снова Gray
+        "У меня тоже долго индексировалось" (2231s). Это продолжение одной
+        мысли, распознанное как отдельный спикер.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Marin_k_a"
+      issue: >
+        Спикер Marin_k_a (189 реплик, 788 сек) НЕ соответствует Марине из
+        справочника. По контексту это Ксения (Ksenks), которая была объявлена
+        ведущим в начале выпуска ("Оксана, она же Ксения").
+    - speaker: "Ksenks"
+      issue: >
+        Ксения объявлена в начале выпуска, но нет ни одной реплики с автором
+        Ksenks. Все её реплики ошибочно помечены как Marin_k_a.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 323
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: >
+      Umputun многократно обращается по имени "Ксюша"/"Оксана" к спикеру
+      Marin_k_a. Ксения объявлена участницей в начале. Marin_k_a (Марина) -
+      отдельный человек, не участвовавший в выпуске 323.
+
+  - type: rename
+    episode: 323
+    from_speaker: "SPEAKER_05"
+    to_speaker: "Gray"
+    confidence: high
+    reason: >
+      Единственная реплика (1.4 сек) между двумя репликами Gray, являющаяся
+      продолжением его мысли.
+
+  - type: rename
+    episode: 323
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: >
+      Единственная реплика продолжает мысль Marin_k_a (которая = Ksenks).
+      Lavale не была объявлена в этом выпуске.

--- a/validation/episodes/0300-0399/0324.yaml
+++ b/validation/episodes/0300-0399/0324.yaml
@@ -1,0 +1,213 @@
+episode: 324
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray, Ksenks]
+  total_duration_sec: 7623  # ~2h07m
+
+# Главная проблема выпуска
+critical_issue:
+  description: "Все реплики Ksenks ошибочно помечены как Marin_k_a"
+  evidence:
+    - "В начале Umputun представляет: 'с нами Ксюша есть сегодня' (18.7s)"
+    - "Bobuk обращается: 'Ксюша, обрати внимание' (40.5s)"
+    - "Umputun на 4846s говорит: 'Это если бы Маруся была бы, она бы сказала' - подтверждает что Марины НЕТ на выпуске"
+    - "К спикеру Marin_k_a обращаются как 'Ксюша' в 9 местах выпуска"
+  resolution: "Переименовать все Marin_k_a -> Ksenks"
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 662
+    replies_count: 165
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибочная атрибуция. Это Ksenks (Ксюша), не Marin_k_a (Марина). Umputun на 4846s прямо говорит что Маруси нет на выпуске."
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. Umputun в начале: "с нами Ксюша есть сегодня" (18.7s)
+        2. Umputun: "Оксана" (30.3s) — завершает представление
+        3. На 4846s: "Это если бы Маруся была бы, она бы сказала" — Марины нет
+        4. К Marin_k_a обращаются "Ксюша" минимум 9 раз в выпуске
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 8
+    replies_count: 6
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие реплики, рассеянные по выпуску. Все являются продолжениями или эхом соседних реплик ведущих."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.6
+          reason: "3 из 6 реплик идут сразу после/перед репликами Gray"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Реплика на 2354s продолжает речь Ksenks (помечена как Marin_k_a)"
+
+      voice_task:
+        needed: false
+        reason: "Слишком короткие реплики (<2 сек каждая) для voice comparison"
+
+      details:
+        - stime: 101.42
+          text: "Бабучка."
+          context: "Эхо фразы Bobuk 'Бабучочка' (98.6s)"
+          likely_speaker: "Bobuk или артефакт"
+        - stime: 2354.87
+          text: "Это просто не нужно."
+          context: "Продолжение Ksenks 'Это не нужно' (2352.5s)"
+          likely_speaker: "Ksenks"
+        - stime: 2861.37
+          text: "И пока, в общем, ничего не противоречит."
+          context: "Между репликами Gray о поиске и соцсетях"
+          likely_speaker: "Gray"
+        - stime: 4071.64
+          text: "И все станет хорошо."
+          context: "После Bobuk о ретина-дисплеях"
+          likely_speaker: "Bobuk"
+        - stime: 4842.57
+          text: "Мне кажется, что прям закладка."
+          context: "После Gray 'Закладка. Да, кажется'"
+          likely_speaker: "Gray"
+        - stime: 7506.38
+          text: "Правда, его нет под Mac."
+          context: "Между репликами Gray об игре"
+          likely_speaker: "Gray"
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 2
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Две очень короткие реплики - междометия, типичные ошибки транскрибирования"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Первая реплика (110s) идёт после диалога о Ксюше"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Короткие реакции характерны для всех ведущих"
+
+      voice_task:
+        needed: false
+        reason: "Слишком короткие реплики (<2 сек)"
+
+      details:
+        - stime: 110.39
+          text: "Да, как-то так."
+          context: "После обсуждения Бобука"
+          likely_speaker: "Ksenks или Bobuk"
+        - stime: 6014.49
+          text: "Хе-хе."
+          context: "Смех после шутки Umputun"
+          likely_speaker: "любой ведущий"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Одиночная короткая реплика между высказываниями Ksenks"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: "Реплика логически продолжает мысль Ksenks и идёт между её репликами"
+
+      voice_task:
+        needed: false
+        reason: "Слишком короткая реплика"
+
+      details:
+        - stime: 5706.62
+          text: "Но это уже не прогрессивно."
+          context: "Между репликами Ksenks (помечена как Marin_k_a) о Google аутентификации"
+          likely_speaker: "Ksenks"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Marin_k_a"
+      issue: "Ошибочное имя. Это Ksenks - представлена в начале как 'Ксюша' и 'Оксана'"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 324
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun в начале представляет Ксюшу (18.7s, 30.3s).
+      На 4846s говорит "если бы Маруся была бы" - подтверждает отсутствие Марины.
+      К спикеру обращаются "Ксюша" минимум 9 раз в выпуске.
+      165 реплик, 662 сек - это полноценное участие ведущей, не гостя.
+
+  - type: merge_or_delete
+    episode: 324
+    speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    action: "Требует ручного анализа каждой реплики"
+    confidence: medium
+    reason: "6 коротких реплик, большинство вероятно принадлежат Gray или Ksenks"
+
+  - type: merge_or_delete
+    episode: 324
+    speaker: "SPEAKER_04"
+    action: "Можно удалить или приписать соседнему спикеру"
+    confidence: medium
+    reason: "2 междометия, нет смысловой нагрузки"
+
+  - type: merge_to_ksenks
+    episode: 324
+    speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    action: "Переименовать в Ksenks"
+    confidence: medium
+    reason: "Реплика логически продолжает мысль Ksenks"
+
+# Дополнительные заметки
+notes: |
+  Эпизод 324 (19 января 2013) - выпуск с "полным составом": Umputun, Bobuk, Gray, Ksenks.
+
+  Главная проблема: Все реплики Ksenks ошибочно атрибутированы как Marin_k_a.
+
+  Доказательства:
+  1. Представление в начале: "с нами Ксюша есть сегодня" (Umputun, 18.7s)
+  2. Называет по имени: "Оксана" (Umputun, 30.3s)
+  3. Явное отрицание присутствия Марины: "Это если бы Маруся была бы, она бы сказала" (Umputun, 4846s)
+  4. Многочисленные обращения "Ксюша" к спикеру Marin_k_a
+
+  Рекомендация: Создать правило очистки для переименования Marin_k_a -> Ksenks в эпизоде 324.

--- a/validation/episodes/0300-0399/0325.yaml
+++ b/validation/episodes/0300-0399/0325.yaml
@@ -1,0 +1,255 @@
+episode: 325
+status: needs_review
+analyzed_at: "2026-01-25T12:00:00Z"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray]
+  guests_present: [EldarMurtazin]
+  total_duration_sec: 7600  # ~2 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  # --- EldarMurtazin: уже идентифицирован, 456 реплик ---
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 1896
+    replies_count: 456
+    pattern: consecutive
+    analysis:
+      is_error: false
+      identified_as: "eldar_murtazin"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "Umputun на 49.8s: 'Эльдар, здравствуй', SPEAKER_00 на 51.4s отвечает 'Привет, ребят', затем EldarMurtazin появляется как спикер с 94.58s"
+
+  # --- Marin_k_a: ОШИБКА - это на самом деле Ksenks ---
+  - speaker: "Marin_k_a"
+    total_duration_sec: 931
+    replies_count: 216
+    pattern: consecutive
+    analysis:
+      is_error: false  # спикер реальный, но неправильно идентифицирован
+      error_reason: null
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. На 1304.78s Umputun говорит: "Ксюшенька появилась, рыбонька"
+        2. Сразу после этого (1307.56s) Marin_k_a говорит: "Привет всем"
+        3. На 6916.68s Umputun говорит: "Ксюша, расскажи пока что-нибудь"
+        4. На 6919.67s отвечает Marin_k_a
+        Marin_k_a в people.yaml - это Марина (бывшая ведущая), но в этом эпизоде
+        это явно Ksenks (Ксения), которую называют "Ксюша/Ксюшенька"
+
+  # --- SPEAKER_00: 4 реплики, требует разбора ---
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 6
+    replies_count: 4
+    pattern: scattered
+    analysis:
+      is_error: false  # часть реплик - Эльдар, часть - ошибки распознавания
+
+      # Разбор по репликам:
+      detailed_breakdown:
+        - stime: 51.4
+          etime: 52.98
+          text: "Привет, ребят."
+          verdict: "EldarMurtazin"
+          confidence: high
+          reason: "Umputun только что сказал 'Эльдар, здравствуй' (49.8s)"
+
+        - stime: 3445.12
+          etime: 3445.42
+          text: "А почему нет Cisco?"
+          verdict: "unknown_short_interjection"
+          confidence: low
+          reason: "Очень короткая реплика (0.3 сек), вставлена между репликами Gray. Может быть любой участник."
+
+        - stime: 5012.68
+          etime: 5013.1
+          text: "Нет."
+          verdict: "unknown_short_interjection"
+          confidence: low
+          reason: "Односложный ответ на вопрос Umputun. Может быть любой участник."
+
+        - stime: 5301.21
+          etime: 5305.34
+          text: "Спариваться на ходу небезопасно?"
+          verdict: "likely_EldarMurtazin_or_Ksenks"
+          confidence: medium
+          reason: "Шутка в ответ на реплику Umputun 'Я париться не буду'. Стиль юмора подходит Эльдару или Ксении."
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5301.21
+          etime: 5305.34
+          text: "Спариваться на ходу небезопасно?"
+          reason: "Единственный сегмент достаточной длины для voice comparison"
+
+  # --- SPEAKER_MISATTRIBUTED_PETR: 3 реплики ---
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 11
+    replies_count: 3
+    pattern: scattered
+    analysis:
+      is_error: true  # MISATTRIBUTED означает, что атрибуция была отменена
+      error_reason: "Ранее эти реплики были ошибочно присвоены PetrDidenko, но Пётр не участвует в этом эпизоде"
+
+      detailed_breakdown:
+        - stime: 2128.84
+          etime: 2134.2
+          text: "Так и было, я слышал."
+          verdict: "likely_EldarMurtazin_or_Gray"
+          reason: "Контекст: обсуждение критики. Скорее всего кто-то из основных участников."
+
+        - stime: 6512.1
+          etime: 6514.0
+          text: "А говорить по пультику."
+          verdict: "likely_EldarMurtazin"
+          reason: "Контекст: обсуждение гаджетов, тема Эльдара."
+
+        - stime: 6910.57
+          etime: 6914.08
+          text: "Они не понимают."
+          verdict: "likely_Ksenks"
+          reason: "Между репликами Umputun, сразу после Umputun говорит 'Ксюша, расскажи'"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2128.84
+          etime: 2134.2
+          text: "Так и было, я слышал."
+          reason: "Самый длинный сегмент (5.4 сек)"
+
+  # --- SPEAKER_MISATTRIBUTED_LAVALE: 1 реплика ---
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 5
+    replies_count: 1
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: "Ранее реплика была ошибочно присвоена Lavale, но Лаваль не участвует в этом эпизоде"
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Реплика идёт сразу после Marin_k_a (которая = Ksenks):
+        - Marin_k_a (6977.01s): "И вот в этом плане поиск BlackBerry ушел."
+        - SPEAKER_MISATTRIBUTED_LAVALE (6981.15s): "Ну и в плане общего впечатления от интерфейсов, наверное."
+        Это продолжение мысли, скорее всего тот же спикер = Ksenks
+
+      voice_task:
+        needed: false  # достаточно контекста для идентификации
+
+  # --- Bobuk: 1 реплика, подозрительно ---
+  - speaker: "Bobuk"
+    total_duration_sec: 4
+    replies_count: 1
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: |
+        В начале эпизода (12.62s) Umputun говорит: "состав у нас сегодня непростой, потому что Бобук решил..."
+        и далее объясняет, что Бобук не участвует. Единственная реплика "Bobuk" на 4885.73s
+        между репликами Gray - скорее всего ошибка распознавания.
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Реплика между двумя репликами Gray, может быть его же реплика"
+        - person_id: "eldar_murtazin"
+          confidence: 0.3
+          reason: "Обсуждают iTunes, тема гаджетов"
+        - person_id: "ksenks"
+          confidence: 0.2
+          reason: "Ksenks также присутствует в эпизоде"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 4885.73
+          etime: 4889.37
+          text: "И почему она работает только для тех, у кого есть американский iTunes?"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Marin_k_a"
+      issue: |
+        КРИТИЧЕСКАЯ ОШИБКА: Marin_k_a (Марина) в этом эпизоде - это на самом деле Ksenks (Ксения).
+        Umputun явно называет её "Ксюшенька" и "Ксюша" перед её репликами.
+        Требуется переименование: Marin_k_a -> Ksenks для эпизода 325.
+
+    - speaker: "Bobuk"
+      issue: |
+        Bobuk не участвует в эпизоде (сказано в начале), но есть 1 реплика.
+        Скорее всего ошибка распознавания - требует voice comparison.
+
+    - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+      issue: "Вероятно это Ksenks (продолжение речи после Marin_k_a=Ksenks)"
+
+    - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+      issue: "3 реплики требуют идентификации, Пётр не участвует в эпизоде"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 325
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun называет спикера "Ксюшенька" (1304.78s) и "Ксюша" (6916.68s).
+      Marin_k_a (Марина) - другой человек. В этом эпизоде это Ksenks (Ксения).
+
+  - type: rename
+    episode: 325
+    from_speaker: "SPEAKER_00"
+    to_speaker: "EldarMurtazin"
+    stime: 51.4
+    etime: 52.98
+    confidence: high
+    reason: "Прямое представление: 'Эльдар, здравствуй' -> 'Привет, ребят'"
+
+  - type: rename
+    episode: 325
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: "Продолжение мысли сразу после Marin_k_a (=Ksenks)"
+
+  - type: remove_or_reassign
+    episode: 325
+    from_speaker: "Bobuk"
+    confidence: medium
+    reason: "Bobuk не участвует в эпизоде (объявлено в начале), 1 реплика - ошибка распознавания"
+
+# Задания на voice comparison
+voice_comparison_tasks:
+  - task_id: "325_speaker00_5301"
+    speaker: "SPEAKER_00"
+    segment:
+      stime: 5301.21
+      etime: 5305.34
+      text: "Спариваться на ходу небезопасно?"
+    compare_with: ["EldarMurtazin", "Ksenks"]
+
+  - task_id: "325_misattributed_petr_2128"
+    speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    segment:
+      stime: 2128.84
+      etime: 2134.2
+      text: "Так и было, я слышал."
+    compare_with: ["EldarMurtazin", "Gray", "Ksenks"]
+
+  - task_id: "325_bobuk_4885"
+    speaker: "Bobuk"
+    segment:
+      stime: 4885.73
+      etime: 4889.37
+      text: "И почему она работает только для тех, у кого есть американский iTunes?"
+    compare_with: ["Gray", "EldarMurtazin", "Ksenks"]

--- a/validation/episodes/0300-0399/0326.yaml
+++ b/validation/episodes/0300-0399/0326.yaml
@@ -1,0 +1,308 @@
+episode: 326
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray, Ksenks]
+  guests_present: []
+  total_duration_sec: 8453
+
+# Примечание: Gray появляется только на 3084s с 2 репликами (4 сек)
+# Ксюша (Ksenks) размечена под двумя разными идентификаторами: Marin_k_a и SPEAKER_00
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 742
+    replies_count: 124
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. На 7828s Bobuk говорит "Пока Ксюша смотрит" сразу после реплики Marin_k_a "Я не уверена, что там прям будет очень весело"
+        2. На 4455s Umputun говорит "А мне кажется, Вобук, ты с Ксюшей не поймете" в контексте диалога с этим спикером
+        3. В people.yaml Marin_k_a описана как "Марина, бывшая ведущая", но контекст ясно показывает что здесь это Ксюша
+        4. На 7821s говорит "Я не Грей" - указывает на женский голос, не Марину
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 420
+    replies_count: 175
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. На 19s отвечает "Викторовна" когда Umputun спрашивает "как по отчеству?" после упоминания "Ксения"
+        2. На 47s отвечает "Надо бы меня не заразить" после слов Bobuk "Из гиков сегодня у нас одна Ксюша"
+        3. Реплики SPEAKER_00 и Marin_k_a не пересекаются по времени - это один человек с разной разметкой
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 6
+    replies_count: 7
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие изолированные фразы в разных местах эпизода (2939s, 7817s).
+        На 2939s - серия коротких фраз ("Ты так написал?", "Посмотри в чатике") в диалоге между SPEAKER_00 и этим спикером - возможно ошибка разделения голоса Ксюши или Бобука.
+        На 7817s - "Оксана?" - возможно фоновая реплика или артефакт.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Контекст диалога с SPEAKER_00, может быть та же Ксюша с неправильной сегментацией"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "На 2939s фразы похожи на технические указания, что характерно для Бобука"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2939.16
+          etime: 2947.06
+          text: "Ты так написал? Посмотри в чатике. Ну, показываю. Копии, подожди. Копии раз. Шер с вами."
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 3
+    replies_count: 2
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Две короткие подряд реплики "Ну, да" на 2650s и 2651s.
+        Типичные подтверждающие междометия, вероятно ошибка распознавания одного из ведущих.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.5
+          reason: "Bobuk задает вопрос про Amazon Transcoder, кто-то соглашается 'Ну, да' - вероятно Umputun"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Также может быть Ксюша подтверждающая слова"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 11
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Эти реплики были ошибочно отнесены к Lavale и помечены как MISATTRIBUTED
+      # Требуется определить реального автора
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        1. На 212s реплика продолжает мысль Marin_k_a (которая = Ksenks) о комьюнити GitHub
+        2. На 4437s реплика в контексте разговора с Ксюшей (после неё Bobuk говорит "как ты написала")
+        Вероятно это реплики Ксюши, ошибочно размеченные как Lavale и затем помеченные как MISATTRIBUTED
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: "Обе реплики в контексте диалогов где участвует Ксюша"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 4437.14
+          etime: 4442.18
+          text: "Вот сейчас там пофишу у себя где-нибудь локально и напишу какое-нибудь там тихое письмо."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 4
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Очень короткие реплики (1-2 сек каждая) в разных частях эпизода.
+        "Конечно" (1540s), "Ужас и кошмар" (3551s), "Просто хитрый перец" (5220s).
+        Эльдар Муртазин НЕ участвовал в этом эпизоде (в начале представлены только Umputun, Bobuk, Ksenks).
+        Это короткие реакции кого-то из присутствующих ведущих.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.4
+          reason: "Короткие эмоциональные реакции могут быть от Umputun"
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Или от Bobuk - оба используют такие фразы"
+        - person_id: "ksenks"
+          confidence: 0.2
+          reason: "Менее вероятно Ксюша"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3551.19
+          etime: 3552.93
+          text: "Ужас и кошмар."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 7
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие реплики в разных частях:
+        "Скорости мне немало и раньше было" (3209s), "Какая маленькая проблема у меня?" (4574s), "Нельзя поднять ничего такого" (7593s).
+        Пётр Диденко НЕ участвовал в этом эпизоде.
+        Реплики выглядят как часть диалога с ведущими.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.5
+          reason: "Реплики на 4574s и 7593s продолжают технические обсуждения Umputun"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Или Bobuk в техническом контексте"
+        - person_id: "ksenks"
+          confidence: 0.2
+          reason: "Менее вероятно"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 4574.66
+          etime: 4576.6
+          text: "Какая маленькая проблема у меня?"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes: |
+    В начале эпизода Umputun представляет участников: "Ксения Викторовна сегодня зашла к нам на огонек, и Бобук Батькович тоже с нами".
+    Gray появляется позже (3084s) без отдельного представления.
+    Эпизод гиковский, гостей нет.
+
+  issues:
+    - speaker: "Marin_k_a"
+      issue: |
+        Неправильный идентификатор спикера. Marin_k_a в people.yaml - это Марина (бывшая ведущая),
+        но в этом эпизоде под этим ID размечена Ksenks (Ксюша). Требуется переименование.
+
+    - speaker: "SPEAKER_00"
+      issue: |
+        Также является Ksenks, но часть её реплик размечена отдельно как SPEAKER_00.
+        Требуется объединение с Marin_k_a и переименование обоих в Ksenks.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 326
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Контекст однозначно показывает что это Ксюша (Ksenks):
+      - Bobuk называет её "Ксюша" во время её реплик
+      - Umputun обращается к "Ксюше" и получает ответ от этого спикера
+      В people.yaml Marin_k_a - это Марина, но здесь это ошибка разметки
+
+  - type: rename
+    episode: 326
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      В начале эпизода SPEAKER_00 отвечает "Викторовна" на вопрос об отчестве Ксении.
+      Это тот же человек что и Marin_k_a, просто с другой разметкой.
+
+  - type: rename
+    episode: 326
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      Обе реплики в контексте разговоров с Ксюшей и продолжают её мысли.
+      Требует voice verification.
+
+# Задания для voice comparison
+voice_comparison_tasks:
+  - task_id: "326_speaker01"
+    speaker: "SPEAKER_01"
+    segment:
+      stime: 2939.16
+      etime: 2947.06
+    candidates: [ksenks, bobuk]
+    priority: low
+
+  - task_id: "326_misattributed_lavale"
+    speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    segment:
+      stime: 4437.14
+      etime: 4442.18
+    candidates: [ksenks]
+    priority: medium
+
+  - task_id: "326_misattributed_eldar"
+    speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    segment:
+      stime: 3551.19
+      etime: 3552.93
+    candidates: [umputun, bobuk]
+    priority: low
+
+  - task_id: "326_misattributed_petr"
+    speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    segment:
+      stime: 4574.66
+      etime: 4576.6
+    candidates: [umputun, bobuk]
+    priority: low

--- a/validation/episodes/0300-0399/0327.yaml
+++ b/validation/episodes/0300-0399/0327.yaml
@@ -1,0 +1,244 @@
+episode: 327
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Контекст: Umputun в начале эпизода (17-23s) сказал "сегодня Ксюша и я. Я и Ксюша. И все."
+# Однако позже появились звонящие гости через Skype
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Ksenks]  # Bobuk и Gray отсутствовали (явно сказано "мы без Бобука")
+  guests_present: [Marin_k_a, VasyaStrelnikov, Ruslan]
+  total_duration_sec: 6400  # примерно 1ч 46мин
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  # SPEAKER_00 - это Ksenks (Ксюша)
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 1027
+    replies_count: 383
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "34.58s: 'Да, привет, я Ксюша, а говорит со мной у Бутон' (искажённое Umputun)"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  # SPEAKER_02 - это Руслан (гость/слушатель)
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 220
+    replies_count: 54
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: null  # не в people.yaml, нужно добавить
+      identification_method: "introduction"
+      confidence: high
+      evidence: "1202-1212s: Umputun говорит 'Да, всем привет Привет, Руслан Ты сказал, что на любую тему...'"
+      possible_matches:
+        - person_id: "ruslan_listener"
+          confidence: 0.95
+          reason: "Прямое обращение по имени от Umputun"
+      voice_task:
+        needed: false  # уже идентифицирован по имени
+
+  # SPEAKER_03 - это Василий Стрельников
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 82
+    replies_count: 36
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "vasya_strelnikov"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "342-345s: Umputun спрашивает 'Василий, это ты появился и шумишь?' и ответ 'Да, я появился и уже шумлю.'"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  # Bobuk - ошибка распознавания
+  - speaker: "Bobuk"
+    total_duration_sec: 6
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Umputun в начале эпизода (221-226s) явно сказал 'Поскольку мы без Бобука'. Единственная реплика Bobuk (440s) находится в середине диалога SPEAKER_03 (Василия) с плохим звуком"
+      identified_as: null
+      possible_matches:
+        - person_id: "vasya_strelnikov"
+          confidence: 0.8
+          reason: "Реплика между репликами SPEAKER_03, Василий звонил с плохим звуком"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 440.25
+          etime: 446.03
+          text: "Вроде сделано отлично, вроде все работает, а что-то не то."
+
+  # Gray - ошибка распознавания
+  - speaker: "Gray"
+    total_duration_sec: 5
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "В начале эпизода Umputun сказал только 'Ксюша и я'. Реплика Gray (424s) находится в том же диалоге, где Василий звонит с плохим звуком"
+      identified_as: null
+      possible_matches:
+        - person_id: "vasya_strelnikov"
+          confidence: 0.7
+          reason: "Реплика в контексте диалога с Василием о плохом звуке"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 423.74
+          etime: 429.16
+          text: "Ну да, ну вот как всегда, я приду и у меня сразу такой звук."
+
+  # SPEAKER_MISATTRIBUTED_ELDAR - ошибочно помеченный как Эльдар
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 54
+    replies_count: 6
+    pattern: scattered
+
+    analysis:
+      is_error: false  # это реальный голос, просто неверно атрибутирован
+      error_reason: null
+      identified_as: null
+      possible_matches:
+        - person_id: "ruslan_listener"
+          confidence: 0.7
+          reason: "Реплики в контексте обсуждения iPad/Surface, где участвовал SPEAKER_02 (Руслан)"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Может быть Ksenks с искажением голоса"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1335.02
+          etime: 1347.39
+          text: "Банально, бывают такие ситуации в работе, когда действительно на коленке очень прикольно какую-нибудь презентажку сбацать..."
+
+  # SPEAKER_MISATTRIBUTED_LAVALE - ошибочно помеченный как Lavale
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 24
+    replies_count: 5
+    pattern: scattered
+
+    analysis:
+      is_error: false  # это реальный голос, просто неверно атрибутирован
+      error_reason: null
+      identified_as: null
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Может быть Ksenks"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Может быть Марина"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2943.98
+          etime: 2951.52
+          text: "Я, насколько помню, многие сходятся во мнении, что Python вообще идеален для изучения, для первого программерского языка."
+
+  # SPEAKER_MISATTRIBUTED_PETR - ошибочно помеченный как Пётр
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 7
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: false  # это реальный голос, просто неверно атрибутирован
+      error_reason: null
+      identified_as: null
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Одиночная реплика, может быть кто угодно из присутствующих"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Обсуждение bash/табов - техническая тема"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3180.68
+          etime: 3187.56
+          text: "То, что они на баше, там табы не очень... Нет, я просто не вижу такой прям хорошей альтернативы."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Bobuk"
+      issue: "Помечен как участник, но Umputun явно сказал 'мы без Бобука'. Вероятно ошибка распознавания."
+    - speaker: "Gray"
+      issue: "Помечен как участник, но в начале не упоминался. Вероятно ошибка распознавания."
+    - speaker: "SPEAKER_02"
+      issue: "Идентифицирован как Руслан, но нет записи в people.yaml. Нужно добавить гостя."
+    - speaker: "Marin_k_a"
+      issue: "Марина не была представлена в начале выпуска. Возможно присоединилась позже или это Ksenks."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 327
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Прямое представление: 'Да, привет, я Ксюша'"
+
+  - type: rename
+    episode: 327
+    from_speaker: "SPEAKER_03"
+    to_speaker: "VasyaStrelnikov"
+    confidence: high
+    reason: "Прямое обращение: 'Василий, это ты появился?' - 'Да, я появился'"
+
+  - type: rename
+    episode: 327
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Ruslan"
+    confidence: high
+    reason: "Прямое обращение: 'Привет, Руслан' (нужно добавить в people.yaml)"
+
+  - type: rename
+    episode: 327
+    from_speaker: "Bobuk"
+    to_speaker: "SPEAKER_NEEDS_REVIEW"
+    confidence: medium
+    reason: "Umputun сказал 'мы без Бобука'. Нужна voice verification для определения спикера."
+
+  - type: rename
+    episode: 327
+    from_speaker: "Gray"
+    to_speaker: "SPEAKER_NEEDS_REVIEW"
+    confidence: medium
+    reason: "Gray не упоминался в начале. Нужна voice verification для определения спикера."
+
+# Дополнительные заметки
+notes: |
+  Эпизод 327 (9 февраля 2013):
+  - Основной состав: Umputun + Ksenks (только они двое анонсированы)
+  - Марина (Marin_k_a) присутствует, но не представлена - возможно это всё ещё Ksenks
+  - Гость Василий Стрельников звонил по Skype с плохим качеством звука
+  - Гость Руслан (слушатель) позвонил в эфир
+  - Bobuk и Gray - скорее всего ошибки распознавания из-за плохого звука Василия
+
+  Требуется:
+  1. Voice verification для Bobuk (440s) и Gray (424s)
+  2. Добавить Ruslan в people.yaml как гостя-слушателя
+  3. Проверить, не является ли Marin_k_a ошибочной атрибуцией Ksenks
+  4. Определить кому принадлежат SPEAKER_MISATTRIBUTED_* реплики

--- a/validation/episodes/0300-0399/0328.yaml
+++ b/validation/episodes/0300-0399/0328.yaml
@@ -1,0 +1,278 @@
+episode: 328
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  total_duration_sec: 6500  # ~1:48 часов
+  notes: |
+    В транскрипте присутствует третий спикер помимо Umputun и Bobuk.
+    Umputun неоднократно обращается к "Ксюше" (17+ раз за выпуск).
+    Однако Ksenks НЕ размечена как спикер.
+    Вместо неё размечены Marin_k_a (112 реплик) и SPEAKER_00 (154 реплики).
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 628
+    replies_count: 112
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Ключевая проблема идентификации
+      identified_as: null  # Требует уточнения - см. ниже
+      identification_method: null
+      confidence: null
+      evidence: |
+        КРИТИЧЕСКИЙ ВОПРОС: Marin_k_a - это Ksenks или отдельный человек?
+
+        Факты ЗА то, что это Ksenks:
+        1. Umputun 17+ раз обращается к "Ксюше" за выпуск
+        2. На каждое обращение к "Ксюше" отвечает Marin_k_a или SPEAKER_00
+        3. Пример 1 (31s): "Ксюша, ты как не обиделась?" -> SPEAKER_00: "Нет, я не обиделась"
+        4. Пример 2 (2067s): "Ксюша, тебе грустно или весело?" -> Marin_k_a отвечает
+        5. Пример 3 (2753s): "А ты, Ксюша, с гитхабом как на ты?" -> Marin_k_a отвечает
+        6. Пример 4 (5611s): "Ты, Ксюша, понял, да?" -> SPEAKER_00 отвечает
+
+        Факты ПРОТИВ:
+        1. В people.yaml Marin_k_a - отдельный гость (Марина, "Бывшая ведущая")
+        2. Ksenks - отдельная запись с real_name "Ксения"
+        3. Марина и Ксения - разные люди
+
+        ВЕРОЯТНАЯ ПРИЧИНА:
+        Marin_k_a и SPEAKER_00 в этом выпуске - это на самом деле Ksenks.
+        Ошибка произошла при первичной разметке транскрипта.
+        Возможно автоматический распознаватель или человек ошибочно
+        приписал голос Ксении к профилю Marin_k_a.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.85
+          reason: "Umputun обращается к 'Ксюше', отвечает Marin_k_a/SPEAKER_00"
+        - person_id: "marin_k_a"
+          confidence: 0.15
+          reason: "Размечено как Marin_k_a в транскрипте, но контекст противоречит"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2757.55
+          etime: 2771.25
+          text: "Ну, я как ты, но так как я смогла с ним разобраться прямо сразу и с насколько не особо там вчиливаясь, я поняла, что гитхаб все-таки написан не чужими для хищников. Бывают, конечно, непонятные моменты."
+        notes: |
+          Сравнить с голосом Ksenks из других выпусков (например, 330-340).
+          Если это Ksenks - все реплики Marin_k_a и SPEAKER_00 нужно переразметить.
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 392
+    replies_count: 154
+    pattern: scattered
+
+    analysis:
+      is_error: false  # Не ошибка распознавания - это реальный человек
+      error_reason: null
+
+      identified_as: null  # Тот же человек, что и Marin_k_a
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        SPEAKER_00 и Marin_k_a - один человек, разбитый на два спикера.
+
+        Доказательства непрерывной речи:
+        1. 38.75s Marin_k_a -> 44.35s SPEAKER_MISATTRIBUTED -> 48.11s SPEAKER_00
+           Один диалог разбит между тремя спикерами
+
+        2. 405.27-409.89s Marin_k_a: "И после этого у меня теперь..."
+           409.95-416.52s SPEAKER_00: "Теперь я могу... Там появилась..."
+           Продолжение одной мысли
+
+        3. 5619.12s Marin_k_a: "Если сравнить сейчас питончик..."
+           5635.99s SPEAKER_00: "Тебе так не кажется?"
+           Одна мысль, завершённая вопросом
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.85
+          reason: "Тот же человек что и Marin_k_a, вероятно Ksenks"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 409.95
+          etime: 417.1
+          text: "Теперь я могу... Там появилась такая кнопочка Open Folder, и можно смотреть в ней файлики. Ну, в общем..."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 4
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Ошибочная атрибуция. Реплика находится между Marin_k_a и SPEAKER_00
+        в одном непрерывном диалоге (38-48 секунды).
+        Текст: "В общем, я думаю, это какие-то счеты между вами, а я ни при чем."
+        Это продолжение предыдущей реплики Marin_k_a, тот же спикер.
+
+      identified_as: null  # Тот же человек что Marin_k_a/SPEAKER_00
+      identification_method: "context"
+      confidence: high
+      evidence: "Контекст диалога 38-48s показывает непрерывную речь одного человека"
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.85
+          reason: "Часть непрерывной речи того же человека"
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Односложная реплика "Хорошо" (177.58-178.58s) между репликами
+        Umputun (177.54s) и Bobuk (178.64s).
+        Вероятно ошибка распознавания или короткая реакция одного из ведущих.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Односложное 'Хорошо' в разговоре Umputun-Bobuk"
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Bobuk говорит сразу после этой реплики"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Третий участник выпуска"
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Односложное "Да" (715.33-716.11s) между репликами Umputun.
+        Типичная ошибка распознавания короткой реакции.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        709.78-715.19s Umputun: "Прям в проводах мало информации хранится"
+        715.33-716.11s SPEAKER_03: "Да."
+        716.15-719.67s Umputun: "А на раутерах..."
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Мог быть краткий ответ Bobuk"
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Мог быть краткий ответ третьего участника"
+
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Ksenks"
+      issue: |
+        Ksenks НЕ размечена как спикер, хотя Umputun обращается к "Ксюше" 17+ раз.
+        Её реплики размечены как Marin_k_a и SPEAKER_00.
+
+    - speaker: "Marin_k_a"
+      issue: |
+        В справочнике Marin_k_a = Марина (бывшая ведущая), но здесь к ней
+        обращаются как к "Ксюше". Вероятная ошибка первичной разметки.
+
+    - speaker: "Gray"
+      issue: |
+        Gray не присутствует в этом выпуске (только Umputun и Bobuk из ведущих).
+        Это нормально - не все ведущие участвуют в каждом выпуске.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 328
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      Umputun обращается к "Ксюше", отвечает Marin_k_a.
+      ТРЕБУЕТСЯ VOICE COMPARISON для подтверждения.
+
+  - type: rename
+    episode: 328
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      SPEAKER_00 и Marin_k_a - один человек (анализ непрерывной речи).
+      Если Marin_k_a = Ksenks, то и SPEAKER_00 = Ksenks.
+      ТРЕБУЕТСЯ VOICE COMPARISON для подтверждения.
+
+  - type: rename
+    episode: 328
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      Часть непрерывного диалога Marin_k_a/SPEAKER_00.
+      Зависит от идентификации основного спикера.
+
+  - type: delete_or_merge
+    episode: 328
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    action: "Определить принадлежность или удалить как шум"
+    confidence: low
+    reason: "Односложная реплика, требует дополнительного анализа"
+
+  - type: delete_or_merge
+    episode: 328
+    from_speaker: "SPEAKER_03"
+    action: "Определить принадлежность или удалить как шум"
+    confidence: low
+    reason: "Односложная реплика 'Да', вероятно ошибка"
+
+# Резюме для ручной проверки
+manual_review_required:
+  priority: high
+  main_question: |
+    Является ли Marin_k_a в этом выпуске на самом деле Ksenks?
+
+  verification_steps:
+    - step: 1
+      action: "Voice comparison Marin_k_a ep.328 vs Ksenks из ep.330-340"
+      audio_url: "Нужно найти в data/328/328_desc.json или использовать CDN"
+      reference_time: "2757-2771 секунды"
+
+    - step: 2
+      action: "Voice comparison Marin_k_a ep.328 vs Marin_k_a из других выпусков"
+      purpose: "Убедиться что это НЕ настоящая Марина"
+
+    - step: 3
+      action: "Если подтвердится Ksenks - применить rename rules"
+
+  expected_outcome: |
+    После voice comparison должно быть ясно:
+    - Если голос = Ksenks: переименовать Marin_k_a, SPEAKER_00, SPEAKER_MISATTRIBUTED_LAVALE -> Ksenks
+    - Если голос = Marin_k_a: понять почему Umputun называет её "Ксюша" (возможно ошибка в транскрипте текста?)

--- a/validation/episodes/0300-0399/0329.yaml
+++ b/validation/episodes/0300-0399/0329.yaml
@@ -1,0 +1,311 @@
+episode: 329
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 6887  # приблизительно, на основе последних таймстемпов
+
+# Важные замечания
+notes:
+  - "Gray в этом выпуске помечен ОШИБОЧНО - спикер представился как 'Александр, занимаюсь игровой журналистикой'"
+  - "Bobuk появляется только в конце выпуска (2 реплики, 12 сек) - возможно он присоединился позже"
+  - "Umputun обращается к 'Ксюше' в начале, но Ksenks нет в спикерах - вероятно это Marin_k_a или SPEAKER_01"
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1121
+    replies_count: 180
+    pattern: consecutive
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "people.yaml"
+      confidence: high
+      evidence: "Марина (бывшая ведущая) согласно people.yaml. Активно участвует с начала выпуска."
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 997
+    replies_count: 293
+    pattern: consecutive
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: "Umputun в начале обращается к 'Ксюше' (19.25s). SPEAKER_01 активно участвует в диалоге с самого начала (92s), женский голос, обсуждает женские темы (подарки на 8 марта, мимоза). Однако Ksenks официально не указана в спикерах этого выпуска."
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: "Umputun обращается к Ксюше, женский голос, активное участие с начала"
+        - person_id: "marin_k_a"
+          confidence: 0.2
+          reason: "Может быть ошибочное разделение Марины на два спикера"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 152.29
+          etime: 180.75
+          text: "Да, я помню цитату, что «Чего вам, мужчины, вас еще поздравлять?... Да-да-да, я сегодня травлю анекдоты."
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 680
+    replies_count: 122
+    pattern: consecutive
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Звонящий Игорь из Украины. Представился сам: 'Добрый вечер, Игорь меня зовут из недалекой Украины' (1668s). Рассказывает о проблемах с Microsoft и переходе на другие ОС."
+      possible_matches:
+        - person_id: null
+          confidence: 0.95
+          reason: "Это звонящий слушатель, не постоянный гость. Имя: Игорь"
+      voice_task:
+        needed: false
+        note: "Идентифицирован как звонящий Игорь из Украины"
+
+  - speaker: "Gray"
+    total_duration_sec: 147
+    replies_count: 17
+    pattern: consecutive
+    analysis:
+      is_error: true
+      error_reason: "ОШИБОЧНАЯ АТРИБУЦИЯ. Спикер представляется: 'меня зовут Александр, и я как бы занимаюсь игровой журналистикой' (6146s). Это НЕ Gray (Сергей Петренко), а звонящий гость Александр."
+      identified_as: null
+      identification_method: "introduction"
+      confidence: high
+      evidence: "Прямое представление: 'меня зовут Александр'. Gray - это Сергей Петренко, не Александр."
+      voice_task:
+        needed: false
+        note: "Явное представление - это Александр, игровой журналист (звонящий)"
+
+  - speaker: "SPEAKER_06"
+    total_duration_sec: 117
+    replies_count: 22
+    pattern: consecutive
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: null
+      identification_method: "context"
+      confidence: medium
+      evidence: "Обсуждает игровые консоли (PlayStation, Xbox, Nintendo) в том же сегменте, где 'Gray' представляется как Александр. Вероятно это тот же человек - Александр, игровой журналист."
+      possible_matches:
+        - person_id: null
+          confidence: 0.8
+          reason: "Тот же звонящий Александр, игровой журналист. Gray и SPEAKER_06 - один человек."
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6288.29
+          etime: 6311.2
+          text: "На самом деле, в последнее время, конечно, все обсуждают скорее облачный гейминг... И есть еще OnLive, но он, к сожалению, разве только в Америке хорошо работает."
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 81
+    replies_count: 31
+    pattern: consecutive
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: null
+      identification_method: "introduction"
+      confidence: high
+      evidence: "Прямое представление: 'Ну, меня зовут Владимир' (6442s). Обсуждает презентацию Sony PlayStation и облачный гейминг."
+      possible_matches:
+        - person_id: null
+          confidence: 0.95
+          reason: "Звонящий Владимир, обсуждает консоли"
+      voice_task:
+        needed: false
+        note: "Идентифицирован как звонящий Владимир"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 54
+    replies_count: 9
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: "Пометка MISATTRIBUTED указывает на отменённое ошибочное присвоение к EldarMurtazin. Это реплики звонящих слушателей."
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Разнородные реплики о Microsoft (1766s), драйверах (2195s), Amazon (2806s), звуке (2950s), Move/Sony (6692s). Последняя реплика (6692s) совпадает по теме со звонящим Александром."
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6692.61
+          etime: 6709.12
+          text: "Sony с проектом Move, который подразумевает под собой джойстик, это более похоже на Wii..."
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 21
+    replies_count: 10
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: "Короткие реплики, разбросанные по выпуску. Вероятно ошибки распознавания голосов Umputun или женских ведущих."
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Реплика 'Я стараюсь сегодня за всех и за бобок с Грэм чуть-чуть' (171s) похожа на Umputun. Но 'Да-да-да, мы молчим, да' (5675s) - может быть кто-то другой."
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.4
+          reason: "Некоторые реплики похожи на стиль Umputun"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Некоторые короткие реплики могут быть женским голосом"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 171.73
+          etime: 175.31
+          text: "Я стараюсь сегодня за всех и за бобок с Грэм чуть-чуть."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 12
+    replies_count: 2
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: "Пометка MISATTRIBUTED указывает на отменённое ошибочное присвоение к Lavale. Две разрозненные реплики."
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Одна реплика об ARC (4128s): 'Если функция не create, то она возвращает объект, прикрепленный уже к авторелиз-полу'. Вторая (5806s): 'Я когда спрашивала у них...' - женский голос."
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Женский голос ('спрашивала'), техническая тема"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Женский голос"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5806.76
+          etime: 5812.63
+          text: "Я когда спрашивала у них, а как вы вообще с этой проблемой живете, как вы ее обходите, меньше копипастите?"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 7
+    replies_count: 1
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: "Пометка MISATTRIBUTED указывает на отменённое ошибочное присвоение к PetrDidenko. Одна реплика."
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Одна реплика о драйверах (2165s): 'Я столкнулся с активным поиском драйверов под эту балалайку...'. Может быть часть разговора звонящего Игоря (SPEAKER_02)."
+      possible_matches:
+        - person_id: null
+          confidence: 0.6
+          reason: "Вероятно продолжение разговора Игоря (SPEAKER_02) о переходе с Windows"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2165.12
+          etime: 2171.74
+          text: "Я столкнулся с активным поиском драйверов под эту балалайку, поскольку облачной платформы в этом чудо-ксероксе нет."
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 0
+    replies_count: 1
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: "Одно слово 'То есть...' - явная ошибка сегментации/распознавания"
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Единственная реплика: 'То есть...' (6021s) длительностью 0.34 сек. Оборванная фраза."
+      voice_task:
+        needed: false
+        note: "Слишком короткий фрагмент для анализа"
+
+  - speaker: "Bobuk"
+    total_duration_sec: 12
+    replies_count: 2
+    pattern: consecutive
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: "bobuk"
+      identification_method: "people.yaml"
+      confidence: high
+      evidence: "Появляется в конце выпуска (6486s). Возможно присоединился к звонку позже или это ошибка распознавания."
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Gray"
+      issue: "КРИТИЧЕСКАЯ ОШИБКА: Помечен как Gray, но представляется как Александр (игровой журналист). Требуется переименование."
+    - speaker: "SPEAKER_01"
+      issue: "Не представлен явно, но активно участвует с начала. Вероятно Ksenks (Umputun обращается к Ксюше)."
+    - speaker: "SPEAKER_06"
+      issue: "Вероятно тот же Александр (игровой журналист), что и ошибочно помеченный Gray."
+    - speaker: "Bobuk"
+      issue: "Очень короткое участие (2 реплики), появляется только в конце. Нетипично для ведущего."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 329
+    from_speaker: "Gray"
+    to_speaker: "Guest_Aleksandr_GameJournalist"
+    confidence: high
+    reason: "Спикер представляется: 'меня зовут Александр, и я как бы занимаюсь игровой журналистикой'. Gray - это Сергей Петренко."
+
+  - type: rename
+    episode: 329
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: "Umputun обращается к Ксюше в начале выпуска, SPEAKER_01 активно участвует, женский голос. Требуется верификация голоса."
+
+  - type: merge
+    episode: 329
+    from_speaker: "SPEAKER_06"
+    to_speaker: "Guest_Aleksandr_GameJournalist"
+    confidence: medium
+    reason: "SPEAKER_06 обсуждает ту же тему (консоли) в том же временном сегменте, что и ошибочно помеченный Gray. Вероятно один человек."
+
+  - type: merge
+    episode: 329
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "Guest_Aleksandr_GameJournalist"
+    confidence: low
+    reason: "Последняя реплика (6692s о Sony Move) совпадает по теме и времени с Александром. Остальные реплики требуют проверки."
+
+# Идентифицированные звонящие слушатели
+identified_callers:
+  - name: "Игорь"
+    speaker_id: "SPEAKER_02"
+    location: "Украина"
+    first_appearance: 1668
+    topic: "Переход с Microsoft на альтернативные ОС"
+
+  - name: "Александр"
+    speaker_id: "Gray (ошибочно), SPEAKER_06"
+    profession: "Игровой журналист"
+    first_appearance: 6146
+    topic: "PlayStation 4, консоли нового поколения"
+
+  - name: "Владимир"
+    speaker_id: "SPEAKER_05"
+    first_appearance: 6442
+    topic: "Презентация Sony, облачный гейминг"

--- a/validation/episodes/0300-0399/0330.yaml
+++ b/validation/episodes/0300-0399/0330.yaml
@@ -1,0 +1,160 @@
+episode: 330
+status: clean
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  # Gray - 1 реплика, явно ошибка распознавания
+  total_duration_sec: 7709  # ~2h08m (Umputun 4504s + Bobuk 3203s + misc)
+  notes: |
+    Umputun в начале выпуска явно говорит: "парный классический состав"
+    и "Кроме того, что состав парный классический, ну что означает, что есть Бобок"
+    Это подтверждает, что в выпуске только два ведущих: Umputun и Bobuk.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одиночная односложная реплика "Нет?" (705.9s) длительностью <1 сек.
+        Контекст: Bobuk рассказывает анекдот про воздушный шар.
+        До реплики: Bobuk "То, как чувак внезапно на воздушном шаре приземляется посреди поля."
+        После реплики: Bobuk "Нет." - сам отвечает на свой вопрос.
+        Вероятно, это переспрос/реакция Umputun, ошибочно размеченная как отдельный спикер.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.85
+          reason: |
+            В эпизоде только двое: Umputun и Bobuk.
+            Реплика вставлена посреди монолога Bobuk,
+            логично что это короткая реакция Umputun.
+
+      voice_task:
+        needed: false
+        # Слишком короткая реплика для voice comparison
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одиночная короткая реплика "Ну, хорошо, да." (573.9s) длительностью <1 сек.
+        Контекст: обсуждение проблемы с видеокартой MacBook Pro.
+        До реплики: Umputun "И никогда после этого не выключается."
+        После реплики: Umputun продолжает "То есть, выключить ее можно не когда вот этот эффект пройдет..."
+        Это типичная фраза-реакция собеседника. Префикс MISATTRIBUTED уже показывает,
+        что это была попытка ошибочной идентификации как Эльдар Муртазин.
+        Эльдара в этом выпуске нет - только Umputun и Bobuk.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.85
+          reason: |
+            В эпизоде только Umputun и Bobuk.
+            Umputun говорит до и после этой реплики.
+            "Ну, хорошо, да" - типичная реакция-согласие Bobuk.
+
+      voice_task:
+        needed: false
+        # Слишком короткая реплика для voice comparison
+
+  - speaker: "Gray"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Gray НЕ УЧАСТВОВАЛ в этом выпуске!
+        Umputun явно говорит в начале: "парный классический состав" (4.55s-11.53s)
+        и "что означает, что есть Бобок" - только двое ведущих.
+
+        Единственная реплика Gray "Глубоко, мне кажется." (3337.8s)
+        длительностью ~1.3 сек - это ошибка распознавания.
+        Контекст: Bobuk читает шутку про Java, Umputun отвечает.
+        Реплика вклинивается между ними - скорее всего это Bobuk или Umputun.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.7
+          reason: |
+            Bobuk только что закончил шутку и спросил "Понимаешь?"
+            "Глубоко, мне кажется" - может быть ироничная реакция Bobuk на свою же шутку.
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: |
+            Umputun продолжает сразу после - возможно это его реакция.
+
+      voice_task:
+        needed: false
+        # Слишком короткая реплика для voice comparison
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes: |
+    Umputun в начале (4.55s-17.18s) четко представляет состав:
+    - "подкаст выходного дня Радио ТИ в парном классическом составе"
+    - "что означает, что есть Бобок. Бобок, скажи здрасте."
+    Никаких гостей не было анонсировано. Выпуск - дуэт Umputun+Bobuk.
+  issues:
+    - speaker: "Gray"
+      issue: |
+        1 реплика от Gray, хотя он не участвовал в выпуске.
+        Это ошибка распознавания, требует исправления.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 330
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Umputun"
+    confidence: medium
+    reason: |
+      Короткий переспрос "Нет?" посреди монолога Bobuk.
+      В выпуске только двое, Bobuk не прерывает сам себя.
+
+  - type: rename
+    episode: 330
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "Bobuk"
+    confidence: medium
+    reason: |
+      Фраза "Ну, хорошо, да." между репликами Umputun.
+      Эльдара в выпуске не было, только Umputun и Bobuk.
+
+  - type: rename
+    episode: 330
+    from_speaker: "Gray"
+    to_speaker: "Bobuk"
+    confidence: medium
+    reason: |
+      Gray не участвовал в выпуске (заявлен "парный состав" без Gray).
+      Реплика "Глубоко, мне кажется" после шутки Bobuk про Java.
+      Скорее всего это Bobuk комментирует свою шутку.

--- a/validation/episodes/0300-0399/0331.yaml
+++ b/validation/episodes/0300-0399/0331.yaml
@@ -1,0 +1,82 @@
+episode: 331
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  total_duration_sec: 5347  # примерно по статистике реплик
+  notes: "Umputun в начале явно говорит 'полный классический состав' - только он и Bobuk"
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 3
+    replies_count: 1
+    pattern: scattered
+
+    # Результат анализа
+    analysis:
+      is_error: true
+      error_reason: >
+        Одна короткая реплика (2.6 сек) в середине диалога между Umputun и Bobuk.
+        Эльдар НЕ представлялся в начале подкаста. Umputun явно говорит что выпуск
+        "в полном классическом составе" (только он и Bobuk). По контексту реплика
+        "То есть ура, товарищи" - ироничная реакция на сообщение Bobuk о приходе
+        Свана в чат, логически принадлежит Bobuk.
+
+      identified_as: "bobuk"
+      identification_method: "context"
+      confidence: medium
+      evidence: >
+        958.56s Bobuk: "Там, говорят, Сван в чатик пришел."
+        960.70s ???: "То есть ура, товарищи."
+        963.39s Umputun: "Да."
+        Фраза является логическим продолжением реплики Bobuk.
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.75
+          reason: "Непосредственно перед этим говорил Bobuk, фраза продолжает его мысль"
+        - person_id: "umputun"
+          confidence: 0.20
+          reason: "Теоретически мог вставить реплику, но менее вероятно по контексту"
+
+      voice_task:
+        needed: true
+        reason: "Требуется подтверждение голосом для medium confidence"
+        reference_segment:
+          stime: 960.7
+          etime: 963.33
+          text: "То есть ура, товарищи."
+        compare_with:
+          - speaker: "Bobuk"
+            reference_stime: 956.82
+            reference_etime: 960.66
+            reference_text: "То есть я не вижу другой причины. Там, говорят, Сван в чатик пришел."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+      issue: >
+        Ошибочная атрибуция - Эльдар не участвовал в этом выпуске.
+        Выпуск явно анонсирован как "классический состав" (Umputun + Bobuk).
+
+# Специальные спикеры (игнорируются)
+special_speakers:
+  - speaker: "SPEAKER_99"
+    replies_count: 2
+    note: "Аудио-артефакты: 'Multitasking of things' и 'SDN' - очень короткие, etime<=stime"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 331
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "Bobuk"
+    confidence: medium
+    reason: >
+      По контексту диалога реплика логически продолжает предыдущую фразу Bobuk.
+      Требуется voice comparison для подтверждения.

--- a/validation/episodes/0300-0399/0332.yaml
+++ b/validation/episodes/0300-0399/0332.yaml
@@ -1,0 +1,269 @@
+episode: 332
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7564  # приблизительно, на основе последних таймкодов
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 303
+    replies_count: 139
+    pattern: consecutive
+    first_appearance_sec: 20
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. Umputun в начале эпизода (45-51 сек): "я просто пытаюсь понять, что вот в голове у Ксюши"
+        2. SPEAKER_01 говорит "Я поняла" (женский род) в 69-71 сек
+        3. Активное участие в диалоге с первых минут как ведущая
+        4. 139 реплик за выпуск - характерно для постоянного ведущего
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 38
+    replies_count: 23
+    pattern: scattered  # но есть блоки по 3-4 реплики подряд
+    first_appearance_sec: 57
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Не удалось однозначно идентифицировать
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Реплики носят диалоговый характер, не артефакты:
+        - 5072-5078 сек: блок из 4 реплик, диалог с Bobuk о "звезде"
+        - 6701-6712 сек: блок из 3 реплик, диалог с Umputun
+        - Стиль речи женский ("Ну, фу, как неинтересно")
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: |
+            SPEAKER_01 уже идентифицирован как Ksenks (139 реплик).
+            SPEAKER_00 может быть тем же человеком с другим распознаванием голоса.
+            Похожий стиль речи, женский голос.
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: |
+            Marin_k_a присутствует в эпизоде (98 реплик).
+            Некоторые реплики SPEAKER_00 идут рядом с её репликами.
+            Но у Marin_k_a уже своя разметка.
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5072.94
+          etime: 5078.46
+          text: "А, то есть ты ее знал, она была не звезда для тебя? Конечно, конечно. Что? Ну, фу, как неинтересно."
+        compare_with:
+          - speaker: "Ksenks"
+            note: "Сравнить с SPEAKER_01 репликами из этого же эпизода"
+          - speaker: "Marin_k_a"
+            note: "Сравнить с размеченными репликами Marin_k_a"
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 1
+    replies_count: 2
+    pattern: scattered
+    first_appearance_sec: 3257
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Только 2 коротких реплики за весь выпуск:
+        - 3256.8 сек: "Ммм..." (0.06 сек)
+        - 5690.8 сек: "20 раз." (0.88 сек)
+        Это междометия и фрагменты, ошибочно выделенные как отдельный спикер.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 5
+    replies_count: 2
+    pattern: scattered
+    first_appearance_sec: 2023
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Это не Lavale - уже помечено как MISATTRIBUTED
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Реплики ранее были ошибочно присвоены Lavale:
+        - 2023.5 сек: "Они не хотят так много делать все-таки." (между Marin_k_a и SPEAKER_01)
+        - 3412.2 сек: "И в следующий раз он не покупает такой телефон." (между Marin_k_a)
+        Контекст указывает на Marin_k_a или Ksenks.
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.6
+          reason: "Обе реплики окружены репликами Marin_k_a, продолжают её мысль"
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Первая реплика идёт перед SPEAKER_01 (Ksenks)"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2023.48
+          etime: 2026.68
+          text: "Они не хотят так много делать все-таки."
+        compare_with:
+          - speaker: "Marin_k_a"
+            note: "Сравнить с размеченными репликами Marin_k_a в этом эпизоде"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 4
+    replies_count: 1
+    pattern: scattered
+    first_appearance_sec: 6935
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Это не Eldar - уже помечено как MISATTRIBUTED
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Реплика ранее была ошибочно присвоена Eldar:
+        - 6935.3 сек: "Сейчас объясню, почему." (между репликами Bobuk)
+        Контекст: Bobuk до и после, один человек вставляет короткую реплику.
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Реплика между двумя репликами Bobuk, может быть его же фраза"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Umputun активен в этом эпизоде, мог вставить комментарий"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6935.27
+          etime: 6939.13
+          text: "Сейчас объясню, почему."
+        compare_with:
+          - speaker: "Bobuk"
+            note: "Сравнить с репликами Bobuk до и после этой"
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 562
+    replies_count: 98
+    pattern: consecutive
+    first_appearance_sec: 60
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Marin_k_a (Марина) - бывшая ведущая, зарегистрирована в people.yaml.
+        В начале эпизода Umputun говорит "улучшатель/улучшалка" про женщину.
+        98 реплик указывают на полноценное участие как соведущей.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes: |
+    В начале эпизода Umputun представляет состав:
+    - Себя (ведущий)
+    - Bobuk ("Бобук, ты тоже с нами?")
+    - Ксюша/Ksenks ("что вот в голове у Ксюши")
+    - "Улучшалка" (женщина, скорее всего Marin_k_a как гость)
+
+    Все основные участники были упомянуты.
+
+  issues:
+    - speaker: "SPEAKER_01"
+      issue: "139 реплик помечены как SPEAKER_01, хотя это явно Ksenks"
+    - speaker: "SPEAKER_00"
+      issue: "23 реплики неидентифицированы, требуется voice comparison"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 332
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun явно упоминает Ксюшу в начале (45-51 сек).
+      SPEAKER_01 использует женский род ("Я поняла").
+      139 реплик - характерно для постоянного ведущего.
+
+  - type: delete
+    episode: 332
+    speaker: "SPEAKER_02"
+    confidence: high
+    reason: |
+      Только 2 реплики общей длительностью 1 сек.
+      "Ммм..." и "20 раз." - междометия, ошибки распознавания.
+      Следует удалить или переназначить соседним спикерам.
+
+# Задачи для ручной проверки
+manual_review_tasks:
+  - task: "voice_comparison"
+    speaker: "SPEAKER_00"
+    priority: medium
+    description: |
+      Определить, является ли SPEAKER_00 тем же человеком что SPEAKER_01 (Ksenks)
+      или это отдельный участник (возможно Marin_k_a).
+      Референс: 5072-5078 сек
+
+  - task: "voice_comparison"
+    speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    priority: low
+    description: |
+      Определить, кому принадлежат эти 2 реплики: Marin_k_a или Ksenks.
+      Референс: 2023-2027 сек
+
+  - task: "voice_comparison"
+    speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    priority: low
+    description: |
+      Определить, кому принадлежит реплика "Сейчас объясню, почему."
+      Вероятно Bobuk или Umputun.
+      Референс: 6935-6939 сек

--- a/validation/episodes/0300-0399/0333.yaml
+++ b/validation/episodes/0300-0399/0333.yaml
@@ -1,0 +1,184 @@
+episode: 333
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray, Ksenks]
+  total_duration_sec: 7541.7
+  notes: "Ksenks присутствует, но размечена как SPEAKER_04 и частично Marin_k_a"
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 281.3
+    replies_count: 101
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        В 254s Umputun прямо обращается "Ксюша?", и в 255s SPEAKER_04 отвечает
+        "Ладно, я расскажу." Многочисленные обращения к Ксюше перед и после реплик
+        SPEAKER_04 подтверждают идентификацию. В 5593s SPEAKER_04 сам упоминает
+        "Ксюша" в третьем лице, но это в контексте цитирования чужих слов.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 270.4
+    replies_count: 45
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Marin_k_a и SPEAKER_04 чередуются в одном разговоре (267s-295s) без каких-либо
+        переходов или представлений. Обе метки говорят на одну тему (Том Круз во
+        ВКонтакте). В 2640s Marin_k_a продолжает разговор, начатый ведущими для Ксюши.
+        Нет ни одного упоминания имени "Марина" в эпизоде. Заключение: это тот же
+        человек что и SPEAKER_04 = Ksenks.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 1.5
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Единственная короткая реплика (1.5s) в 2632s - ошибка распознавания"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "Контекст похож на разговор с Ksenks, реплика вписывается в диалог"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Реплика между двумя репликами Umputun, может быть его"
+
+      voice_task:
+        needed: false
+        reason: "Слишком короткая реплика для voice comparison"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 3.6
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Две короткие изолированные реплики (2554s: "Радиоприемника." и 7217s:
+        "Дальше у нас есть повторение тем.") - это ошибки распознавания,
+        вероятнее всего Umputun или другие ведущие.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.7
+          reason: "Реплика 7217s типична для перехода между темами - это делает ведущий"
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 4.1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика (5650s: "И это активно обсуждается в подкасте Радио Тип")
+        - ошибка распознавания. Лаваль не участвовала в этом эпизоде.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Контекст обсуждения подкаста, но без voice comparison не определить"
+
+      voice_task:
+        needed: false
+        reason: "Короткая реплика, low priority"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "SPEAKER_04"
+      issue: "Ksenks не размечена корректно - 101 реплика под меткой SPEAKER_04"
+    - speaker: "Marin_k_a"
+      issue: "Ksenks частично размечена как Marin_k_a (45 реплик) - ошибка diarization"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 333
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Прямое обращение "Ксюша?" в 254s перед ответом SPEAKER_04 в 255s.
+      Множественные упоминания Ксюши в контексте реплик SPEAKER_04.
+
+  - type: rename
+    episode: 333
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Marin_k_a и SPEAKER_04 чередуются в одном диалоге, говорят на одну тему,
+      нет упоминаний имени Марина. Это та же персона что и SPEAKER_04 = Ksenks.
+
+  - type: rename
+    episode: 333
+    from_speaker: "SPEAKER_03"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: "Единственная реплика в контексте диалога с Ksenks, вероятно её"
+
+  - type: rename
+    episode: 333
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "Umputun"
+    confidence: medium
+    reason: "Короткие реплики ведущего, вторая типична для перехода между темами"
+
+  - type: rename
+    episode: 333
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Bobuk"
+    confidence: low
+    reason: "Недостаточно контекста, предположение на основе темы разговора"

--- a/validation/episodes/0300-0399/0334.yaml
+++ b/validation/episodes/0300-0399/0334.yaml
@@ -1,0 +1,222 @@
+episode: 334
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray, Bobuk]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7772
+  notes: |
+    Umputun в начале говорит "безбубуковский состав" (9-12 сек),
+    но Bobuk присоединяется с 544 секунды (первая реплика).
+    Marin_k_a вызывается как "Ксюша" Umputun'ом — это НЕ Ksenks,
+    а другой человек (Марина), которую называли Ксюшей.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 431
+    replies_count: 169
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        SPEAKER_00 использует женский род: "я видела" (1451s, 1456s),
+        "я общалась" (3173s), "я вспомнила" (4797s), "я перестала" (3723s).
+        Чередуется с Marin_k_a в одном монологе — реплики продолжают друг друга:
+        - Marin_k_a (1443-1450): "я видела это только вот у IT гиков"
+        - SPEAKER_00 (1451-1456): "в их руках я видела, а у живых людей"
+        - Marin_k_a (1456-1459): "это тоже были такие люди"
+        Это один человек, разбитый на два спикера автотранскрипцией.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reason: "Идентифицирован по контексту с высокой уверенностью"
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1026
+    replies_count: 166
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Umputun обращается "Ксюша, можешь повторить?" (30s),
+        Marin_k_a отвечает "Нет, но я попробую" (32s).
+        Umputun: "Ксюша, тебе выбор" (77s).
+        В people.yaml Marin_k_a записана как "Марина (бывшая ведущая)".
+        Возможно, "Ксюша" — это домашнее/ласкательное прозвище Марины.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reason: "Уже идентифицирован в people.yaml"
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 5
+    replies_count: 4
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Очень короткие реплики (в среднем 1.25 сек), разбросанные по всему эпизоду:
+        - 374s: "Кому это нужно вообще?" (1.8 сек)
+        - 1546s: "У тебя еще и доисторическая." (2.6 сек)
+        - 6849s: "Ну..." (0.04 сек)
+        - 7349s: "Хотя я не знаю..." (0.8 сек)
+        Это ошибки распознавания — короткие реплики одного из ведущих,
+        неправильно атрибутированные.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.4
+          reason: "Некоторые реплики по стилю похожи на Gray"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Может быть неправильно распознанная Marin_k_a"
+
+      voice_task:
+        needed: false
+        reason: "Реплики слишком короткие для voice comparison"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 31
+    replies_count: 8
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Маркер SPEAKER_MISATTRIBUTED означает отменённое ранее присвоение.
+        Реплики разбросаны: 966s, 2114s, 2266s, 3403s, 4311s, 6502s, 7632s, 7646s.
+        Контекст реплик:
+        - "А он по ВНС куда пошел?" (966s) — вопрос о VNC, технический
+        - "Там супер-пупер атака" (2114s) — обсуждение DDoS-атак
+        - "Windows RT" тема (7632-7646s)
+        Голос мужской, но не похож на Eldar Murtazin (который не участвует в 334).
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Технические вопросы о VNC, атаках — похоже на стиль Gray"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Bobuk появляется позже, некоторые реплики могут быть его"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 7632.23
+          etime: 7649.94
+          text: "Нет, ну тут есть еще темы про Windows 8 и опять про Украину. ... Microsoft прекращает поддержку Windows RT как самостоятельного продукта."
+          notes: "Самый длинный непрерывный сегмент SPEAKER_MISATTRIBUTED_ELDAR"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 6
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Только 2 реплики, 6 секунд суммарно:
+        - 2965s: "А так все остальное вообще... Ты понимаешь, там конкретные просто наезды." (3.8 сек)
+        - 5719s: "Потому что я был не в курсе." (2.3 сек)
+        Очень мало данных для идентификации. Скорее всего ошибки распознавания.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.4
+          reason: "Первая реплика идёт сразу после Umputun, может быть его продолжением"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Вторая реплика в контексте обсуждения с Gray"
+
+      voice_task:
+        needed: false
+        reason: "Реплики слишком короткие для voice comparison"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  bobuk_late_arrival: true
+  notes: |
+    1. Umputun говорит "безбубуковский состав" в начале (9-12 сек),
+       но Bobuk появляется с 544 секунды — возможно, присоединился позже по звонку.
+    2. Marin_k_a называется "Ксюша" — в people.yaml она Марина.
+       Требует уточнения: либо это прозвище, либо ошибка в справочнике.
+    3. SPEAKER_00 = Marin_k_a с высокой уверенностью (женский род, чередование реплик).
+
+  issues:
+    - speaker: "SPEAKER_00"
+      issue: "Должен быть переименован в Marin_k_a"
+    - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+      issue: "Требует voice comparison для идентификации"
+    - speaker: "Marin_k_a"
+      issue: "В people.yaml указано real_name='Марина', но Umputun называет её 'Ксюша'"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 334
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Marin_k_a"
+    confidence: high
+    reason: |
+      SPEAKER_00 использует женский род, чередуется с Marin_k_a в едином монологе,
+      продолжая её мысли. Это один и тот же человек.
+
+  - type: delete
+    episode: 334
+    speaker: "SPEAKER_01"
+    confidence: medium
+    reason: |
+      4 реплики по 1-2 сек каждая — типичные ошибки распознавания.
+      Можно удалить или оставить для ручной проверки.
+
+# Вопросы для ручной проверки
+manual_review_questions:
+  - question: "Marin_k_a — это Марина или Ксения (Ksenks)?"
+    context: |
+      Umputun обращается к ней как "Ксюша", но в people.yaml
+      она записана как Марина (бывшая ведущая).
+      Возможно, "Ксюша" — ласкательное от "Марина"?
+      Или это разные люди?
+
+  - question: "Кто такой SPEAKER_MISATTRIBUTED_ELDAR?"
+    context: |
+      8 реплик (31 сек) с мужским голосом.
+      Eldar Murtazin не участвует в этом выпуске.
+      Возможно Gray или другой ведущий.

--- a/validation/episodes/0300-0399/0335.yaml
+++ b/validation/episodes/0300-0399/0335.yaml
@@ -1,0 +1,228 @@
+episode: 335
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Ksenks]  # размечена как Marin_k_a и SPEAKER_00
+  total_duration_sec: 8689.68
+
+# Ключевое наблюдение
+# В конце эпизода (8620-8627с) Umputun прямо говорит:
+# "Я напомню, что с нами, хотя многие не заметили, была Ксюша"
+# SPEAKER_00 отвечает: "Да, я была чуть-чуть"
+# Это однозначно подтверждает, что SPEAKER_00 = Ksenks
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 292.1
+    replies_count: 52
+    pattern: consecutive  # появляется блоками, ведёт технические диалоги
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибочная разметка. Это Ksenks, не Марина. Подтверждается: (1) Umputun обращается к 'Ксюше' перед репликами (680с, 2541с), (2) В финале (8620с) подтверждается присутствие Ксюши, (3) Технические темы (Java, Objective-C, тесты) соответствуют профилю Ksenks"
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        8620с: Umputun: "Я напомню, что с нами, хотя многие не заметили, была Ксюша"
+        680с: Umputun: "Ксюша, у меня к тебе вопрос, как к специалисту по конспирологии" -> Marin_k_a отвечает
+        2541с: Umputun: "Ксюшенька, у меня к тебе вот вопрос" -> после этого идёт диалог
+
+      possible_matches: []
+      voice_task:
+        needed: false  # идентификация надёжная
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 117.7
+    replies_count: 53
+    pattern: scattered  # короткие реплики вперемежку с Marin_k_a
+
+    analysis:
+      is_error: true
+      error_reason: "Это тот же человек что и Marin_k_a = Ksenks. Реплики чередуются в одном диалоге (например, 713-724с)"
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        8625с: После "была Ксюша" отвечает SPEAKER_00: "Да, я была чуть-чуть"
+        47с: Umputun: "Ксюша, здравствуй" -> SPEAKER_00: "Здравствуйте"
+        157-161с: SPEAKER_00 отвечает на вопросы, адресованные Ксюше
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 1.1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткая реплика (1 сек) в середине диалога Umputun. Скорее всего ошибка распознавания или это один из ведущих"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "1132с: 'И начнут от него чего-то.' — обрывок фразы между репликами Umputun"
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.6
+          reason: "Контекст — Umputun говорит до и после, могла быть ошибка сегментации"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Также участвует в диалоге"
+
+      voice_task:
+        needed: false  # слишком короткая реплика
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 3.0
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткая реплика о скорости браузеров. Контекст: разговор о Chrome/Blink. Нет признаков присутствия Эльдара"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "1443с: 'Жаль, что к стейбл-версии теряется это преимущество скорости.' — технический комментарий"
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Тема соответствует, Ksenks активна в этот момент"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Bobuk отвечает сразу после"
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 0.9
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткая реплика сразу после обращения к Ксюше. Это явно Ksenks"
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        2541с: Umputun: "Ксюшенька, у меня к тебе вот вопрос, потому что Грею с таким вопросом ходить смешно"
+        2546с: SPEAKER_MISATTRIBUTED_LAVALE: "Лучше к Бобуку" — ответ на обращение к Ксюше
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 0.4
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Односложная реплика 'Да.' в конце эпизода (5501с). Скорее всего ошибка распознавания"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "5501с: 'Да.' — слишком короткая для идентификации"
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Ksenks активна в эпизоде"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Участвует в разговоре"
+
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes: |
+    Ksenks представлена в начале (47с) и подтверждена в конце (8620с).
+    Однако её реплики ошибочно размечены как Marin_k_a и SPEAKER_00.
+    Нет реального спикера Ksenks в транскрипте несмотря на её участие.
+
+  issues:
+    - speaker: "Ksenks"
+      issue: "Отсутствует в разметке, хотя явно участвует. Реплики ошибочно приписаны Marin_k_a и SPEAKER_00"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 335
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun явно обращается к Ксюше перед репликами Marin_k_a (680с, 2541с).
+      В конце эпизода подтверждается участие Ксюши (8620с).
+      Марина (Marin_k_a) не упоминается в эпизоде.
+
+  - type: rename
+    episode: 335
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Прямое подтверждение: Umputun говорит "была Ксюша", SPEAKER_00 отвечает "Да, я была".
+      SPEAKER_00 отвечает на обращения к "Ксюше" (47с, 157с).
+
+  - type: rename
+    episode: 335
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Реплика сразу после прямого обращения к Ксюше"
+
+  - type: delete_or_merge
+    episode: 335
+    speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    confidence: medium
+    reason: "Обрывок фразы в середине монолога Umputun, вероятно ошибка сегментации"
+
+  - type: delete_or_merge
+    episode: 335
+    speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    confidence: medium
+    reason: "Короткая реплика без контекста присутствия Эльдара"
+
+  - type: delete_or_merge
+    episode: 335
+    speaker: "SPEAKER_04"
+    confidence: medium
+    reason: "Односложная реплика, ошибка распознавания"
+
+# Референсные сегменты для voice comparison (если понадобится)
+voice_reference_segments:
+  marin_k_a_long:
+    description: "Длинный осмысленный фрагмент Marin_k_a (=Ksenks)"
+    stime: 1599.49
+    etime: 1625.71
+    duration_sec: 26.2
+    text_preview: "То есть, если в какой-то момент... Ну, Google никак не может повлиять..."
+
+  speaker_00_confirmation:
+    description: "SPEAKER_00 подтверждает что она Ксюша"
+    stime: 8625.24
+    etime: 8627.14
+    duration_sec: 1.9
+    text: "Да, я была чуть-чуть."

--- a/validation/episodes/0300-0399/0336.yaml
+++ b/validation/episodes/0300-0399/0336.yaml
@@ -1,0 +1,205 @@
+episode: 336
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [Ksenks]  # Ksenks выступает как гость, не ведущая в этом выпуске
+  total_duration_sec: 7500  # ~2 часа (приблизительно)
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 859
+    replies_count: 230
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        В 34.9 сек Umputun говорит: "Ксюша наверняка знает, она недавно в школе училась."
+        В 38.6 сек SPEAKER_01 отвечает: "Нет, ну я не так уж недавно, но я согласна с Бабуком, определенно грек."
+        Прямое обращение по имени и ответ от SPEAKER_01 - явная идентификация.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 254
+    replies_count: 43
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # В people.yaml Marin_k_a - это Марина, бывшая ведущая
+      # Однако контекст показывает проблему: на "Ксюшенька" отвечает Marin_k_a
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Проблема идентификации: в 280 сек Umputun говорит "Ксюшенька, ты как?",
+        но отвечает Marin_k_a (286 сек). Это может означать:
+        1) Marin_k_a - это на самом деле Ksenks (ошибка разметки)
+        2) Марина и Ксюша обе присутствуют, но их путают
+        В people.yaml Marin_k_a записана как отдельный человек "Марина, бывшая ведущая".
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "На обращение 'Ксюшенька' отвечает Marin_k_a"
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "В people.yaml это отдельный гость 'Марина'"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 286.25
+          etime: 301.8
+          text: "Ну да, я тут еще недавно была на конференции, там был работник GitHub, у него перед докладом были технические проблемы, и он предложил задавать ему любые вопросы, вплоть до, не знаю, что-нибудь рассказать о своих дочерях, и вот спросили..."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 33
+    replies_count: 7
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Метка MISATTRIBUTED указывает, что ранее ошибочно присвоено Lavale
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Реплики ранее были ошибочно присвоены Lavale и отменены.
+        Пример реплики (2283.9s): "Давайте сделаем вот просто там на каждую десятую дюйма, так будет классно."
+        Следующая реплика (2296.6s): "Мне очень понравилась шутка в плане этого устройства."
+        Контекст - обсуждение Samsung Galaxy Mega с Ксюшей.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: "Реплики в контексте обсуждения с Ксюшей, вероятно это её голос с ошибкой распознавания"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2283.92
+          etime: 2288.94
+          text: "Давайте сделаем вот просто там на каждую десятую дюйма, так будет классно."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 6
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие разрозненные реплики (2 шт, 6 сек), ранее ошибочно присвоенные Петру Диденко"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Реплика 1 (1226.9s): "Там так все непрактично сделано." - в контексте обсуждения iOS клиента
+        Реплика 2 (6104.6s): "К сожалению или к счастью... Расскажи, да, ты же с ними общался?" - в контексте обсуждения образования
+        Обе реплики короткие, разбросаны на ~80 минут, не типичны для настоящего гостя.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Может быть Ксюша с ошибкой распознавания"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Контекст вопроса про образование указывает на возможную ошибку при Bobuk"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 28
+    replies_count: 15
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие разрозненные реплики, типичные ошибки распознавания"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Первые реплики (49-51 сек): "Арифм." и "Да-да-да." - эхо/повтор за Umputun
+        Остальные реплики разбросаны по выпуску, все короткие (1-3 сек).
+        Примеры: "Так что мы еще услышим", "Именно так", "Странное, да, голосование"
+        Типичные фразы-подтверждения от разных спикеров.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Marin_k_a"
+      issue: |
+        Неясно, присутствует ли в эпизоде отдельно Марина или это ошибка разметки Ksenks.
+        На обращение "Ксюшенька" отвечает Marin_k_a, что указывает на возможную путаницу.
+        Требуется voice comparison для подтверждения.
+
+    - speaker: "SPEAKER_01 vs Marin_k_a"
+      issue: |
+        Оба спикера демонстрируют связь с Ксюшей, но размечены по-разному.
+        Возможно это один человек (Ksenks) с двумя разными тегами из-за ошибки распознавания.
+        Рекомендуется проверить голосом и объединить если подтвердится.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 336
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Явное представление: Umputun обращается 'Ксюша', SPEAKER_01 отвечает от первого лица"
+
+  - type: rename
+    episode: 336
+    from_speaker: "SPEAKER_00"
+    to_speaker: "SPEAKER_99"
+    confidence: medium
+    reason: "Короткие эхо-реплики, типичные артефакты распознавания, можно игнорировать"
+
+  - type: investigate
+    episode: 336
+    speakers: ["Marin_k_a", "SPEAKER_MISATTRIBUTED_LAVALE"]
+    confidence: medium
+    reason: |
+      Требуется voice comparison:
+      1) Определить, является ли Marin_k_a на самом деле Ksenks
+      2) Если Marin_k_a != Ksenks, определить кому принадлежат SPEAKER_MISATTRIBUTED_LAVALE
+
+# Примечания
+notes: |
+  Эпизод 336 от 13 апреля 2013 года.
+  Ведущие: Umputun (основной) и Bobuk (удалённо, "через спутник").
+  Гость: Ksenks (Ксюша) - упоминается явно.
+
+  Главная проблема: путаница между Marin_k_a и SPEAKER_01.
+  Оба могут быть Ksenks, но требуется проверка.
+
+  В people.yaml Marin_k_a записана как "Марина, бывшая ведущая" -
+  если это отдельный человек, то в эпизоде могут быть и Марина, и Ксюша одновременно.

--- a/validation/episodes/0300-0399/0337.yaml
+++ b/validation/episodes/0300-0399/0337.yaml
@@ -1,0 +1,241 @@
+episode: 337
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun]
+  guests_present: [Marin_k_a]
+  # Bobuk, Gray, Ksenks, Alek.sys отсутствуют (Umputun: "подкаст в половинном составе")
+  total_duration_sec: ~7500
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 859
+    replies_count: 349
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        В начале выпуска Umputun говорит "Сегодня Ксюша будет зажигать" (56.67s),
+        затем SPEAKER_03 отвечает "Я сегодня за гада?" (60.38s).
+        SPEAKER_03 активно участвует во всём выпуске, ведёт темы,
+        говорит "Я помню, да" на вопрос о традициях подкаста.
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 25
+    replies_count: 13
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие разрозненные реплики ("Да", "Ну да", "PCRE, да").
+        Появляется в начале (7.6s) когда Umputun спрашивает "Ксюша?".
+        Скорее всего это ошибочно распознанные реплики Ksenks (SPEAKER_03).
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.9
+          reason: "Первая реплика — ответ на 'Ксюша?', все реплики короткие подтверждения"
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 118
+    replies_count: 35
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: null
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Слушатель по имени Руслан, позвонивший рассказать про Xen.
+        Umputun: "Руслан говорит, хочу про Зен рассказать" (5470.29s),
+        "Ну, расскажи нам, Руслан" (5473.61s), затем SPEAKER_00: "Алло, привет" (5480.44s).
+        Рассказывает о своём опыте использования Xen в продакшене.
+      possible_matches: []
+      voice_task:
+        needed: false
+        # Слушатель-звонящий, не требует идентификации
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 111
+    replies_count: 13
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Ошибочная атрибуция. Это НЕ Эльдар Муртазин, а тот же слушатель Руслан.
+        Реплики EldarMurtazin идут вперемежку с SPEAKER_00 в том же разговоре о Xen.
+        Контекст: обсуждение Xen в продакшене продолжается без смены говорящего.
+        EldarMurtazin (5568s): "Ну, я его использую в продакшене последние 3-4 года"
+        — это продолжение рассказа Руслана.
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "listener_ruslan"
+          confidence: 0.95
+          reason: "Тот же контекст разговора, что и SPEAKER_00, без смены темы"
+      voice_task:
+        needed: false
+
+  - speaker: "Bobuk"
+    total_duration_sec: 5
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Bobuk отсутствует в этом выпуске (Umputun: "половинный состав").
+        Единственная реплика (5852.84s) идёт в контексте разговора Руслана о Xen,
+        между репликами EldarMurtazin и SPEAKER_00. Это часть того же монолога.
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "listener_ruslan"
+          confidence: 0.95
+          reason: "Реплика между другими репликами того же говорящего в разговоре о Xen"
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 9
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Уже помечен как MISATTRIBUTED. Реплики принадлежат другим спикерам:
+        - 2167.46s: продолжение монолога Marin_k_a об обсуждениях в команде
+        - 5417.67s: вероятно SPEAKER_03 (Ksenks), переход к теме слушателей
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.8
+          reason: "Реплика в 2167s — продолжение речи Марины"
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: "Реплика в 5417s — рядом с SPEAKER_03"
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1754
+    replies_count: 270
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Марина (бывшая ведущая) — один из двух ведущих в "половинном составе".
+        Активно участвует с самого начала (27.78s), обсуждает темы наравне с Umputun.
+        Упоминается контекстно: "Мариса в гнев вошла" (2111.86s, Umputun цитирует историю).
+      possible_matches: []
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "EldarMurtazin"
+      issue: "Ошибочная атрибуция — это слушатель Руслан, не Эльдар Муртазин"
+    - speaker: "Bobuk"
+      issue: "Bobuk отсутствует в выпуске, реплика принадлежит Руслану"
+    - speaker: "SPEAKER_02"
+      issue: "Скорее всего это Ksenks, ошибочно распознанная отдельно"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 337
+    from_speaker: "SPEAKER_03"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Явное представление в начале выпуска: 'Ксюша будет зажигать'"
+
+  - type: rename
+    episode: 337
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: "Короткие реплики, первая — ответ на обращение 'Ксюша?'"
+
+  - type: rename
+    episode: 337
+    from_speaker: "EldarMurtazin"
+    to_speaker: "Ruslan_listener"
+    confidence: high
+    reason: "Это слушатель Руслан, не Эльдар Муртазин; тот же контекст что и SPEAKER_00"
+
+  - type: rename
+    episode: 337
+    from_speaker: "Bobuk"
+    to_speaker: "Ruslan_listener"
+    confidence: high
+    reason: "Bobuk отсутствует в выпуске; реплика внутри монолога Руслана о Xen"
+
+  - type: rename
+    episode: 337
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ruslan_listener"
+    confidence: high
+    reason: "Слушатель Руслан, представлен Umputun'ом перед звонком"
+
+  - type: merge
+    episode: 337
+    speakers: ["SPEAKER_MISATTRIBUTED_LAVALE"]
+    to_speaker: "Marin_k_a"
+    segments: [2167.46]
+    confidence: medium
+    reason: "Продолжение монолога Марины"
+
+  - type: merge
+    episode: 337
+    speakers: ["SPEAKER_MISATTRIBUTED_LAVALE"]
+    to_speaker: "Ksenks"
+    segments: [5417.67]
+    confidence: medium
+    reason: "Объявление темы слушателей, рядом с репликами SPEAKER_03"
+
+# Дополнительные замечания
+notes: |
+  Выпуск 337 от 20 апреля 2013 года.
+  "Половинный состав" — только Umputun и Marin_k_a (Марина) из постоянных ведущих.
+  Ksenks (SPEAKER_03) — со-ведущая, но распознана как SPEAKER_03.
+
+  Слушатель Руслан позвонил рассказать про Xen (~5470-5900 сек).
+  Его реплики ошибочно размечены как SPEAKER_00, EldarMurtazin и Bobuk.
+
+  ВАЖНО: EldarMurtazin — это НЕ известный мобильный аналитик Эльдар Муртазин.
+  В контексте выпуска это имя никогда не звучит, только "Руслан".

--- a/validation/episodes/0300-0399/0338.yaml
+++ b/validation/episodes/0300-0399/0338.yaml
@@ -1,0 +1,230 @@
+episode: 338
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun]
+  guests_present: [PetrDidenko, Marin_k_a]
+  total_duration_sec: 7824  # ~2 часа 10 минут
+  notes: |
+    Bobuk отсутствует (в начале Umputun говорит "без Бобука, потому что Бобук больной и едет в Украину").
+    Marin_k_a в этом эпизоде = Ксюша (Umputun обращается к ней "Ксюша", "Ксюшенька").
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 549
+    replies_count: 215
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибка распознавания голоса Marin_k_a"
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. После обращения "Ксюшенька, ты в теме?" (366s) отвечает Marin_k_a, затем SPEAKER_03 продолжает фразой "Ну, закрыла я свой ноутбук" (379s) — женский род указывает на того же человека.
+        2. В строке 1105 (379s) SPEAKER_03 использует "закрыла" — это Ксюша/Марина.
+        3. Реплики SPEAKER_03 и Marin_k_a чередуются без пауз в единой беседе.
+        4. Umputun многократно обращается к "Ксюша", и отвечает либо Marin_k_a, либо SPEAKER_03.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 27
+    replies_count: 5
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибочное присвоение Lavale, на самом деле это Marin_k_a"
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. Фраза "Я просто разговаривала с разными командами" (1787s) — женский род "разговаривала".
+        2. Контекст: реплика между двумя репликами Marin_k_a о Git.
+        3. Имя SPEAKER_MISATTRIBUTED_LAVALE указывает, что это уже было исправлено (отменено присвоение Lavale).
+        4. Все 5 реплик идут в контексте обсуждения Git/GitHub, которое ведёт Marin_k_a.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 16
+    replies_count: 11
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие междометия, распределённые по всему эпизоду — ошибка распознавания"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Типичные реплики: "Ага" (1490s), "Ну, да, да" (5934s), "Да" (3888s), "Пока" (7823s).
+        Средняя длительность реплики ~1.5 сек — слишком короткие для надёжной идентификации.
+        Вероятно это ошибочно распознанные реплики основных участников.
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Некоторые реплики в контексте диалога с Marin_k_a"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Короткие реакции могут быть от ведущего"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6071.92
+          etime: 6073.82
+          text: "По три часа каждую неделю?"
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 2
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Всего 2 короткие реплики — явная ошибка распознавания"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Реплики: "Ну, до сих пор, например." (2154s) и "Ну да." (6089s).
+        Обе реплики очень короткие (<2 сек) и разбросаны по эпизоду.
+        Слишком мало данных для идентификации.
+
+      possible_matches:
+        - person_id: "petr_didenko"
+          confidence: 0.4
+          reason: "Фразы похожи на стиль Пети"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Может быть ошибка голоса Ксюши"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "PetrDidenko"
+    total_duration_sec: 1745
+    replies_count: 457
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "petr_didenko"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Umputun в начале (40-48s): "у нас сегодня два с половиной человека собралось... Петя, здравствуй."
+        Петя отвечает (49s): "Привет, привет."
+        Известный постоянный гость подкаста (148 выпусков согласно people.yaml).
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1125
+    replies_count: 216
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Umputun обращается к ней как "Ксюша" многократно по всему эпизоду.
+        В people.yaml: Marin_k_a = Марина, но в этом эпизоде она называется Ксюша.
+        Это бывшая ведущая подкаста.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Marin_k_a"
+      issue: |
+        В people.yaml Marin_k_a = Марина, но Umputun называет её Ксюша.
+        Возможно это разные люди, или у Марины есть прозвище Ксюша.
+        Требуется уточнение: Marin_k_a и Ksenks — это один человек или разные?
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 338
+    from_speaker: "SPEAKER_03"
+    to_speaker: "Marin_k_a"
+    confidence: high
+    reason: |
+      SPEAKER_03 использует женский род ("закрыла"), отвечает на обращения "Ксюша",
+      реплики чередуются с Marin_k_a в единой беседе без пауз.
+
+  - type: rename
+    episode: 338
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Marin_k_a"
+    confidence: high
+    reason: |
+      Женский род в реплике ("разговаривала"), контекст между репликами Marin_k_a,
+      тема обсуждения Git совпадает.
+
+  - type: review
+    episode: 338
+    from_speaker: "SPEAKER_02"
+    to_speaker: null
+    confidence: medium
+    reason: |
+      11 коротких реплик требуют voice comparison для точной идентификации.
+      Предположительно это ошибки распознавания Marin_k_a или Umputun.
+
+  - type: ignore
+    episode: 338
+    from_speaker: "SPEAKER_04"
+    to_speaker: null
+    confidence: high
+    reason: |
+      Всего 2 реплики общей длительностью 2 секунды — можно игнорировать
+      или объединить с ближайшим спикером по контексту.
+
+# Дополнительные заметки
+notes: |
+  Эпизод 338 от 27 апреля 2013 года.
+  Состав: Umputun (ведущий), PetrDidenko (гость), Marin_k_a (Ксюша, бывшая ведущая).
+  Bobuk отсутствует.
+
+  Основная проблема: голос Marin_k_a частично распознан как SPEAKER_03 (215 реплик)
+  и SPEAKER_MISATTRIBUTED_LAVALE (5 реплик). Рекомендуется объединить все эти
+  реплики под Marin_k_a.
+
+  Вопрос для уточнения: в people.yaml Marin_k_a имеет real_name "Марина", но
+  Umputun обращается к ней "Ксюша". Нужно уточнить, это одно лицо или путаница.

--- a/validation/episodes/0300-0399/0339.yaml
+++ b/validation/episodes/0300-0399/0339.yaml
@@ -1,0 +1,246 @@
+episode: 339
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Ksenks]
+  guests_present: [Marin_k_a, "Guest_Alexey"]
+  total_duration_sec: 8938  # ~2.5 часа
+  notes: |
+    В начале подкаста представлены 4 участника: Umputun, Bobuk, Ksenks и гость Алексей.
+    Gray не был представлен и, скорее всего, не участвовал в этом выпуске.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 321
+    replies_count: 85
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        stime=58.98: Umputun: "И есть у нас еще одна участница... Ксения, пожалуйста, как ваше отчество?"
+        stime=67.63: SPEAKER_00: "Погонял, я думала, ты сейчас спросишь."
+        stime=71.27: SPEAKER_00: "А, отчество, точно, настаиваешь, Викторовна."
+        stime=74.55: Umputun: "Так вот, это Ксюша."
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 1291
+    replies_count: 226
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: null
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        stime=21.3: Umputun: "Прежде всего, гость. Я представлю гостя. Как тебя представляют?"
+        stime=25.1: SPEAKER_02: "Алексей."
+        stime=26.82: Umputun: "Вот никакого погоняла, никаких имен поганых. Чисто Алексей, как мама с папой."
+        stime=32.6: SPEAKER_02: "Да, как назвали."
+
+        Гость представлен только как "Алексей" без фамилии/никнейма.
+        Существенное участие в обсуждении (1291 сек, 226 реплик).
+      possible_matches:
+        - person_id: "alek_sys"
+          confidence: 0.2
+          reason: "Имя Алексей, но Alek.sys обычно представлен как ведущий, а не гость"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 179.48
+          etime: 183.69
+          text: "Хорошая ремарка была как для меня, как для профессора."
+        notes: |
+          Нужно определить, кто этот гость Алексей.
+          Возможно, это разовый гость. Нужен voice comparison или поиск в архивах подкаста.
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 336
+    replies_count: 56
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Marin_k_a уже есть в people.yaml как "Марина, бывшая ведущая".
+        Активное участие в технических обсуждениях (ООП, git bisect).
+        stime=138.27: "Объектно-ориентированное программирование уже не стоит изучать..."
+        stime=4154.05: "Смотри, Жень, ты можешь запустить... У тебя есть проект, у тебя есть тесты..." (объясняет git bisect)
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 19
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Это отменённые ошибочные присвоения (MISATTRIBUTED).
+        Короткие фрагменты (3 реплики, 19 сек) в потоке речи других спикеров.
+        stime=208.32: "Но вообще есть мнение, что если человек..." — находится между репликами SPEAKER_00 (Ksenks).
+        stime=211.74: SPEAKER_00 продолжает: "только после учебного заведения..."
+        Это явно продолжение речи Ksenks, разбитое на части.
+      identified_as: null
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.8
+          reason: "Контекст показывает продолжение речи SPEAKER_00"
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 8
+    replies_count: 5
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Отменённые ошибочные присвоения.
+        Очень короткие фрагменты (5 реплик, 8 сек) — типичные ошибки распознавания.
+        stime=2554.34: "То есть там ничего исправлять не надо." (1.5 сек)
+        stime=4049.09: "Ничего себе у тебя вопросы." (1.7 сек)
+        Короткие реакции, вероятно принадлежащие кому-то из ведущих.
+      identified_as: null
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Короткие реактивные фразы типичны для Бобука"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Может быть Umputun"
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 0
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика длительностью 0.48 сек.
+        stime=4151.72: "Объясните мне."
+        Находится между Bobuk ("А что это такое?") и Marin_k_a (объяснение git bisect).
+        Скорее всего это продолжение вопроса Bobuk или артефакт.
+      identified_as: null
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.7
+          reason: "Логическое продолжение его вопроса 'А что это такое?'"
+      voice_task:
+        needed: false
+
+  - speaker: "Gray"
+    total_duration_sec: 3
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Gray НЕ БЫЛ представлен в начале подкаста.
+        Umputun представил только: гостя Алексея, Bobuk, Ksenks.
+        Единственная реплика Gray в 7480s: "Ну, понятно." (3 сек).
+        Это явная ошибка распознавания — Gray не участвовал в этом выпуске.
+      identified_as: null
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.6
+          reason: "Короткая подтверждающая фраза между репликами Umputun и Bobuk"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Может быть реакция Umputun"
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Gray"
+      issue: |
+        Gray не был представлен в начале подкаста, но имеет 1 реплику.
+        В начале Umputun представил состав: "четырех специалистов широкого профиля" —
+        гость Алексей, Bobuk, Ksenks и сам Umputun. Gray не упоминался.
+        Реплика Gray в 7480s скорее всего ошибка распознавания.
+
+    - speaker: "SPEAKER_02"
+      issue: |
+        Гость представлен только как "Алексей" без дополнительной информации.
+        Нужно определить его личность для корректной атрибуции.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 339
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Явное представление: 'Ксения... Викторовна... это Ксюша'"
+
+  - type: rename
+    episode: 339
+    from_speaker: "Gray"
+    to_speaker: "Bobuk"
+    confidence: medium
+    reason: |
+      Gray не был представлен в этом выпуске.
+      Единственная реплика "Ну, понятно" находится в контексте разговора
+      между Umputun и Bobuk. Скорее всего это Bobuk.
+
+  - type: merge_into_previous
+    episode: 339
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    confidence: medium
+    reason: "Фрагменты являются продолжением речи SPEAKER_00 (Ksenks)"
+
+  - type: merge_into_previous
+    episode: 339
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Bobuk"
+    confidence: medium
+    reason: "Единственная реплика — продолжение вопроса Bobuk"
+
+  - type: ignore
+    episode: 339
+    speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    confidence: low
+    reason: "Короткие артефактные реплики, нужна дополнительная проверка"
+
+# Задачи требующие внимания
+tasks:
+  - type: identify_guest
+    speaker: "SPEAKER_02"
+    priority: medium
+    description: |
+      Определить кто такой гость "Алексей" в выпуске 339.
+      Нужно: поиск в архивах подкаста, voice comparison.
+    reference_segment:
+      stime: 179.48
+      etime: 183.69
+      text: "Хорошая ремарка была как для меня, как для профессора."
+
+  - type: verify_voice
+    speaker: "Gray"
+    priority: low
+    description: |
+      Подтвердить, что реплика "Ну, понятно." в 7480s не принадлежит Gray.
+      Скорее всего это Bobuk.

--- a/validation/episodes/0300-0399/0340.yaml
+++ b/validation/episodes/0300-0399/0340.yaml
@@ -1,0 +1,169 @@
+episode: 340
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  # Ksenks присутствует но размечена как SPEAKER_05
+  total_duration_sec: 8550  # примерно 2.4 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 237
+    replies_count: 88
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: "Это Ksenks (Ксюша), ошибка автоматического распознавания"
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Umputun обращается: "Ксюша, а у меня к тебе вопрос" (3861s),
+        следующая реплика SPEAKER_05 (3875s): "Нет, в смысле, а что с ним случилось?"
+        Также в начале эпизода (28s): "У нас есть Ксюша, которая приходит постоянно",
+        но её реплики (74s+) размечены как SPEAKER_05.
+        SPEAKER_05 говорит от первого лица женского рода: "я очень активно пилила" (288s)
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 428
+    replies_count: 59
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Marin_k_a уже в people.yaml как Марина (бывшая ведущая).
+        Реплики технически содержательные, участвует в обсуждениях
+        Ubuntu, Debian, Windows 8, iOS разработки.
+        Не была явно представлена в начале эпизода, но это типично
+        для бывших ведущих.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 129
+    replies_count: 29
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "eldar_murtazin"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        EldarMurtazin уже в people.yaml. Первое появление (1513s) —
+        комментарий про Microsoft и Tami Reller. Обсуждает мобильные
+        технологии, Windows, игры — типичные для него темы.
+        Подключился без явного представления (возможно по звонку).
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 4
+    replies_count: 5
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Очень короткие реплики (0.08-1.78 сек) разбросаны по эпизоду:
+        - 4803s: "Угу." (0.08 сек)
+        - 6261s: "И ужаснуться." + "Подожди, подожди..." (1.9 сек)
+        - 7992s: "Угу." (0.12 сек)
+        - 8524s: "Давайте заканчиваем." (1.78 сек)
+        Паттерн типичен для ошибок распознавания — междометия и короткие
+        реплики ведущих неправильно атрибутированы.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.5
+          reason: "Реплика 'Давайте заканчиваем' (8524s) типична для ведущего"
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Междометия 'Угу' могут быть от любого ведущего"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6261.84
+          etime: 6263.76
+          text: "И ужаснуться. Подожди, подожди, нет, ты..."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_05"
+      issue: |
+        Ksenks (Ксюша) упомянута в начале ("У нас есть Ксюша"),
+        но все её реплики размечены как SPEAKER_05.
+        Требуется переименование SPEAKER_05 -> Ksenks.
+
+    - speaker: "Marin_k_a"
+      issue: |
+        Марина не была представлена в начале эпизода.
+        Это может быть нормально для бывшей ведущей, но стоит проверить.
+
+    - speaker: "EldarMurtazin"
+      issue: |
+        Эльдар Муртазин не был представлен в начале.
+        Появляется внезапно на 1513s в контексте обсуждения Microsoft.
+        Возможно подключился по звонку или присоединился позже.
+
+    - speaker: "SPEAKER_04"
+      issue: |
+        Неопределённый спикер с короткими репликами.
+        Скорее всего ошибки распознавания ведущих.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 340
+    from_speaker: "SPEAKER_05"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Прямое доказательство: Umputun обращается "Ксюша" -> следует ответ SPEAKER_05.
+      Ксюша упомянута как присутствующая в начале, но реплики размечены как SPEAKER_05.
+      SPEAKER_05 говорит от женского рода ("я пилила").
+
+  - type: review_manual
+    episode: 340
+    from_speaker: "SPEAKER_04"
+    to_speaker: null
+    confidence: medium
+    reason: |
+      5 коротких реплик по всему эпизоду — требуется voice comparison
+      для определения, это один из ведущих или отдельный спикер.
+      Рекомендуется прослушать сегменты вокруг 6261-6263s и 8524-8526s.
+
+# Audio URL для voice comparison
+audio_url: "https://cdn.radio-t.com/rt_podcast340.mp3"

--- a/validation/episodes/0300-0399/0341.yaml
+++ b/validation/episodes/0300-0399/0341.yaml
@@ -1,0 +1,295 @@
+episode: 341
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [PetrDidenko]
+  total_duration_sec: 8400  # ~2h 20min based on speaker stats
+
+# Проблема: Ksenks упоминается в разговоре ("Ксюша"), но её реплики
+# помечены как Marin_k_a и SPEAKER_00. Требуется ручная проверка.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "PetrDidenko"
+    total_duration_sec: 627
+    replies_count: 197
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "petr_didenko"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        В начале эпизода (11-14s): Umputun спрашивает "Кто из вас плюс один привел?",
+        Bobuk отвечает "Я. Плюс один, сегодня я просто."
+        Затем (18s): "А Петя тогда плюс еще один."
+        PetrDidenko (24-33s): "Я сам привелся, я шел сегодня по французскому парку..."
+        Также упоминается работа в Microsoft (111s): "В Microsoft, когда я работал..."
+        Это полностью соответствует Петру Диденко из справочника (148 выпусков).
+
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 168
+    replies_count: 28
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Реплики помеченные как Marin_k_a на самом деле принадлежат Ksenks.
+        Доказательства:
+        1. В начале (56-62s) Umputun представляет состав: "есть Грей, есть Ксюша. Ксюша, скажи."
+           После этого SPEAKER_05 отвечает "Да."
+        2. По всему эпизоду обращения к "Ксюше" (строки 1081, 2197, 3016, 12052, 19369, 20827)
+           и реплики Marin_k_a/SPEAKER_00 следуют за ними.
+        3. На строке 2197 "Что за мероприятие было, Ксюшенька?" - отвечает SPEAKER_00
+           "Да, я даже смотрела" (женский род).
+        4. Никаких упоминаний "Марины" в эпизоде нет.
+        5. В финале (20791) "Спасибо, Катя" - но это скорее всего ошибка транскрипции
+           или относится к кому-то в чате.
+
+      identified_as: null  # Требует ручной верификации
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.95
+          reason: |
+            Все обращения к женщине в эпизоде - "Ксюша/Ксюшенька".
+            Марина (Marin_k_a) НЕ упоминается. Ksenks была ведущей в 2013.
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3522.76
+          etime: 3544.5
+          text: |
+            Статистика очень удобная, и причем занятно, что на презентации говорили именно про русский язык.
+            То есть вышла такая прекрасная девушка и говорила, вот, вы смотрите в статистике,
+            ваше приложение скачивает больше всего из России, соответственно, вам нужно перевести это на русский язык.
+            И дальше они показывали свой трансляционный сервис, что тоже забавно.
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 188
+    replies_count: 75
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        SPEAKER_00 - это тот же человек, что и Marin_k_a (система разметки
+        не смогла консистентно атрибутировать один голос).
+        Контекст показывает, что это Ksenks:
+        - 833-858s: отвечает на вопрос к "Ксюшеньке", говорит "смотрела" (ж.р.)
+        - 3501-3521s: технический контекст (Translation сервис, Android)
+        - Реплики чередуются с Marin_k_a как один разговор
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.95
+          reason: "Тот же голос что и Marin_k_a, контекст указывает на Ksenks"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 851.42
+          etime: 858.88
+          text: |
+            Я думаю, их только успокаивало, что вот я сейчас выйду и продам этот пиксель.
+            И, по крайней мере, заработаю на этом ивенте.
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 0
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Две короткие реплики:
+        1. 61.6s: "Да." - ответ на "Ксюша, скажи" -> это Ksenks
+        2. 7732.5s: "Он 48." - короткая вставка, неясный контекст
+        Слишком короткие сегменты для отдельного спикера.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.8
+          reason: "Первая реплика точно ответ Ксюши, вторая неясна"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 30
+    replies_count: 6
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Спикер помечен как "MISATTRIBUTED" - ранее ошибочно атрибутирован EldarMurtazin.
+        Эльдар НЕ участвовал в эпизоде 341 (нет представления, нет упоминаний).
+        Реплики контекстуально принадлежат Gray:
+        - 4550s: "С точки зрения юзабилити..." -> следующая реплика Gray продолжает мысль
+        - 5338s: "...все то, что ты там поотмечал и разметил, это рекомендация" -> Gray продолжает тему сниппетов
+        - 8250s: "С тековым флоу подозреваемый..." -> рядом с Bobuk, технический контекст
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.7
+          reason: |
+            Реплики тематически связаны с высказываниями Gray
+            (юзабилити, поисковая оптимизация). Gray много говорит в этих сегментах.
+        - person_id: "bobuk"
+          confidence: 0.2
+          reason: "Некоторые реплики могут быть Bobuk"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 4550.19
+          etime: 4555.2
+          text: "С точки зрения юзабилити делается очень простая вещь."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 7
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одна реплика, ранее ошибочно атрибутирована Lavale.
+        Lavale НЕ участвовала в эпизоде 341.
+        5785s: "Да-да-да, там про сообщения, которыми общаются."
+        Контекст: разговор о Skype и instant messaging.
+        Скорее всего это Ksenks (SPEAKER_00/Marin_k_a) или один из мужских голосов.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Короткое подтверждение, может быть женский голос"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Или мужской голос в диалоге"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5785.54
+          etime: 5792.92
+          text: "Да-да-да, там про сообщения, которыми общаются."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Ksenks"
+      issue: |
+        Ksenks упоминается по имени 15+ раз как "Ксюша/Ксюшенька",
+        но в списке спикеров её нет. Её реплики размечены как Marin_k_a и SPEAKER_00.
+        Марина (Marin_k_a) вообще НЕ упоминается в эпизоде.
+
+    - speaker: "SPEAKER_MISATTRIBUTED_*"
+      issue: |
+        Спикеры EldarMurtazin и Lavale НЕ участвовали в эпизоде 341.
+        Их имена нигде не упоминаются. Эти реплики были ошибочно атрибутированы
+        и теперь помечены MISATTRIBUTED, но требуют правильной атрибуции.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 341
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Все обращения к женщине в эпизоде - "Ксюша". Марина не упоминается.
+      Ksenks была ведущей в 2013 году и присутствовала в "полном составе".
+
+  - type: rename
+    episode: 341
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      SPEAKER_00 и Marin_k_a - один и тот же голос (Ksenks).
+      Реплики чередуются в одном контексте, отвечают на обращения к "Ксюше".
+
+  - type: rename
+    episode: 341
+    from_speaker: "SPEAKER_05"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      Первая реплика (61.6s "Да") - точно ответ Ксюши на "Ксюша, скажи".
+      Вторая реплика неясна, но скорее всего тоже она.
+
+  - type: rename
+    episode: 341
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "Gray"
+    confidence: medium
+    reason: |
+      Требует voice comparison. Контекст указывает на Gray
+      (юзабилити, поисковая оптимизация), но может быть и другой ведущий.
+
+  - type: rename
+    episode: 341
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: low
+    reason: |
+      Требует voice comparison. Короткая реплика,
+      может быть Ksenks или кто-то из ведущих.
+
+# Комментарий
+notes: |
+  Эпизод 341 (18 мая 2013) имеет серьёзные проблемы с атрибуцией женского голоса.
+
+  Официальный состав: Umputun, Bobuk, Gray, Ksenks + гость PetrDidenko.
+  В начале Umputun говорит "полный состав, плюс один" и "квинтет" (5 человек).
+
+  Главная проблема: реплики Ksenks размечены как Marin_k_a, хотя:
+  1. Марина НЕ упоминается в эпизоде ни разу
+  2. К "Ксюше" обращаются 15+ раз
+  3. Marin_k_a (Марина) - другой человек, бывшая ведущая
+
+  Рекомендация: переименовать Marin_k_a -> Ksenks для этого эпизода.
+  Также SPEAKER_00 и SPEAKER_05 - скорее всего тоже Ksenks.
+
+  SPEAKER_MISATTRIBUTED_ELDAR и SPEAKER_MISATTRIBUTED_LAVALE требуют
+  voice comparison для точной атрибуции.

--- a/validation/episodes/0300-0399/0342.yaml
+++ b/validation/episodes/0300-0399/0342.yaml
@@ -1,0 +1,223 @@
+episode: 342
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7605  # ~2 часа 6 минут (по статистике из задания)
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 405
+    replies_count: 175
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        В начале выпуска (8-11s) Umputun обращается: "Ксюша, выпуск номер?"
+        SPEAKER_00 отвечает (24-26s): "342 я запомнила", "И этот 342 выпуск..."
+        Umputun (47s): "Ксюша, ты за два" — SPEAKER_00 отвечает: "Я даже подумала, что я за два"
+        Женский голос, активное участие в диалогах, обращения по имени.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 991
+    replies_count: 164
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Уже идентифицирована в people.yaml как Марина (бывшая ведущая).
+        Активно участвует в обсуждениях, ведёт темы (222s: рассказывает о статье Guardian про ВКонтакте).
+        Говорит связными длинными репликами, участвует на протяжении всего выпуска.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 5
+    replies_count: 6
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Очень короткие реплики (0.1-2 сек) разбросаны по всему выпуску:
+        - 870s: "Да." (0.14 сек) x2 — ответ на вопрос Umputun "Ты в многоэтажном доме живешь?"
+        - 2639s: "Конечно, сэр." — Umputun сразу повторяет "Конечно, сэр." (вероятно, его реплика)
+        - 3623s: "4 тысячи лет?"
+        - 3705s: "Да, да."
+        - 7187s: "Бисексуалам тоже можно." — вставка между Marin_k_a и SPEAKER_00
+        Похоже на ошибки сегментации при распознавании речи — реплики других участников.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Часть коротких реплик может быть от Ksenks (SPEAKER_00)"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Реплика 'Конечно, сэр' в контексте диалога с Umputun"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Реплика про бисексуалов между её высказываниями"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единичная реплика (2513s): "Ну, а что, конечно."
+        Ранее была ошибочно присвоена Эльдару Муртазину и отменена.
+        В контексте: Umputun говорит про веб-пай, затем эта реплика, затем снова Umputun "Простите."
+        Скорее всего это реплика одного из ведущих (Bobuk или реакция на что-то).
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Короткая ироничная реакция, типичная для Bobuk"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Может быть реакция Ksenks"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2512.67
+          etime: 2515.06
+          text: "Ну, а что, конечно."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 5
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единичная реплика (4340s): "Либо там это были просто гики какие-то, которых Google тоже мало."
+        Ранее была ошибочно присвоена Лаваль и отменена.
+        Контекст: обсуждение Google Code, до реплики SPEAKER_00, после — Marin_k_a.
+        По смыслу продолжает мысль SPEAKER_00 о Google.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "Продолжение мысли SPEAKER_00 (Ksenks), тот же контекст"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Рядом с её репликами, похожий стиль"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 4339.98
+          etime: 4344.81
+          text: "Либо там это были просто гики какие-то, которых Google тоже мало."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_00"
+      issue: |
+        Ksenks присутствует под неправильным именем SPEAKER_00.
+        Требуется переименование SPEAKER_00 -> Ksenks.
+    - speaker: "Marin_k_a"
+      issue: |
+        Марина не была явно представлена в начале (не нашёл фразы "у нас в гостях Марина").
+        Однако она упоминается как "Ксюшенька" рядом, что указывает на знакомство.
+        Возможно представление было в предыдущих выпусках или отрезано.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 342
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun явно обращается к SPEAKER_00 как "Ксюша" (8s, 47s).
+      SPEAKER_00 отвечает женским голосом, участвует активно.
+      175 реплик, 405 сек — слишком много для случайной ошибки.
+
+  - type: merge_or_review
+    episode: 342
+    from_speaker: "SPEAKER_03"
+    to_speaker: null
+    confidence: medium
+    reason: |
+      6 коротких реплик (<5 сек суммарно) — скорее всего ошибки сегментации.
+      Нужен ручной анализ каждой реплики для определения реального спикера.
+
+  - type: review
+    episode: 342
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: null
+    confidence: low
+    reason: |
+      Единичная короткая реплика. Требует voice comparison для определения.
+
+  - type: review
+    episode: 342
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: null
+    confidence: medium
+    reason: |
+      Единичная реплика в контексте обсуждения Google Code.
+      Вероятно Ksenks (продолжение её мысли), но нужна проверка.
+
+# Заметки для ручной проверки
+notes: |
+  Эпизод 342 от 25 мая 2013 года.
+  Состав: Umputun, Bobuk, Ksenks (как SPEAKER_00), Marin_k_a (Марина).
+
+  Основное действие: переименовать SPEAKER_00 -> Ksenks (высокая уверенность).
+
+  SPEAKER_03, SPEAKER_MISATTRIBUTED_ELDAR, SPEAKER_MISATTRIBUTED_LAVALE —
+  единичные/короткие реплики, скорее всего ошибки распознавания.
+  Суммарно ~12 сек из 7600+ сек — незначительное влияние на качество.

--- a/validation/episodes/0300-0399/0343.yaml
+++ b/validation/episodes/0300-0399/0343.yaml
@@ -1,0 +1,182 @@
+episode: 343
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [Marin_k_a, Lavale]
+  total_duration_sec: ~7200  # ~2 часа гиковский выпуск
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 325
+    replies_count: 103
+    pattern: scattered  # разбросаны по всему выпуску
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Это Ksenks (Ксюша), неправильно размеченная
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. SPEAKER_00 говорит "Я запомнила мостик" (120.1s) - женский род
+        2. SPEAKER_00 обращается "Да, Бабок, продолжай" (122.5s) - знает ведущих
+        3. SPEAKER_00 чередуется с Marin_k_a при обсуждении темы Ubuntu (157-225s)
+        4. В контексте Umputun говорит "На тебя, Ксюша, намекаю" (95.3s) перед репликами SPEAKER_00
+        5. SPEAKER_00 и Marin_k_a обе являются Ксюшей - автоматическое распознавание
+           разделило одного спикера на два ID
+
+      possible_matches: []
+
+      voice_task:
+        needed: false  # Идентификация высокой уверенности
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 299
+    replies_count: 48
+    pattern: consecutive  # реплики идут группами
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Это тоже Ksenks (Ксюша), но размеченная под другим ником
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. Umputun говорит "А ты, Ксюша, как к ходупу?" (624.4s) - отвечает Marin_k_a (630.6s)
+        2. Umputun говорит "Ксюша, а ты как?" (3866.5s) - отвечает Marin_k_a (3875.8s)
+        3. Umputun говорит "после объяснения Ксюши" (6069.6s) после объяснений Marin_k_a
+        4. Marin_k_a рассказывает первую тему про Ubuntu bug #1, которую анонсировали
+           словами "Ксюша как самая близкая к этому племени [молодому]"
+        5. ВАЖНО: В people.yaml Marin_k_a указана как "Марина, бывшая ведущая" -
+           это ОШИБКА в справочнике для данного эпизода. В выпуске 343 Marin_k_a = Ksenks
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "Lavale"
+    total_duration_sec: 129
+    replies_count: 18
+    pattern: scattered  # появляется периодически во второй половине
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Lavale - реальная гостья, уже есть в people.yaml
+      identified_as: "lavale"
+      identification_method: "existing_record"
+      confidence: high
+      evidence: |
+        1. Lavale есть в people.yaml как "бывшая ведущая"
+        2. Появляется с 2238s (37 мин) - присоединилась позже
+        3. Говорит о кроссплатформенной разработке "пищуки и маки" (3890s)
+        4. Отличается от Marin_k_a/SPEAKER_00 по времени появления и темам
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 0.06
+    replies_count: 1
+    pattern: isolated
+
+    analysis:
+      is_error: true
+      error_reason: "Одиночная реплика длиной 0.06 сек ('Ну,') - артефакт распознавания"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "SPEAKER_00"
+      issue: "Должен быть переименован в Ksenks - это ошибка автоматического распознавания"
+    - speaker: "Marin_k_a"
+      issue: |
+        В данном эпизоде Marin_k_a = Ksenks (Ксюша), а НЕ Марина.
+        Возможно, автоматическое распознавание использовало профиль голоса Марины,
+        но в контексте эпизода все обращения к этому спикеру идут как "Ксюша".
+        Требует переименования в Ksenks.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 343
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      SPEAKER_00 использует женский род ("запомнила"), знает ведущих ("Бабок, продолжай"),
+      чередуется с Marin_k_a при обсуждении общих тем. Контекст показывает, что это Ксюша.
+
+  - type: rename
+    episode: 343
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Все обращения к Marin_k_a в этом эпизоде идут как "Ксюша":
+      - "А ты, Ксюша, как к ходупу?" -> отвечает Marin_k_a
+      - "Ксюша, а ты как?" -> отвечает Marin_k_a
+      - "после объяснения Ксюши" -> после объяснений Marin_k_a
+      Это ошибка распознавания, спутавшего голос Ксюши с Мариной.
+
+  - type: delete
+    episode: 343
+    from_speaker: "SPEAKER_03"
+    to_speaker: null
+    confidence: high
+    reason: "Артефакт распознавания: реплика 0.06 сек с текстом 'Ну,'"
+
+# Примечания для ручной проверки
+notes: |
+  ## Главная проблема эпизода
+
+  В этом выпуске Ksenks (Ксюша) была размечена двумя разными спикерами:
+  - SPEAKER_00 (103 реплики)
+  - Marin_k_a (48 реплик)
+
+  Это произошло из-за ошибки автоматического распознавания голоса, которое
+  спутало голос Ксюши с профилем Марины (Marin_k_a).
+
+  ## Доказательства
+
+  1. В начале выпуска Umputun объявляет: "День защиты детей, поэтому Ксюша
+     как самая близкая к этому племени" - и дальше тему рассказывает Marin_k_a
+
+  2. Umputun многократно обращается к Ксюше, и каждый раз отвечает либо
+     SPEAKER_00, либо Marin_k_a:
+     - "Ксюша, как к ходупу?" -> Marin_k_a
+     - "Ксюшенька" -> SPEAKER_00 отвечает "Мы потерпим"
+
+  3. SPEAKER_00 говорит "Я запомнила" (женский род) и "Бабок, продолжай"
+
+  4. Фраза "Ксюша, которая оказалась Ксюшей, а не Оксаной" после объяснений
+     от Marin_k_a подтверждает, что это Ксюша
+
+  ## Рекомендация
+
+  Объединить SPEAKER_00 и Marin_k_a в Ksenks для этого эпизода.
+
+  ВАЖНО: Lavale - это отдельная реальная гостья, НЕ переименовывать.

--- a/validation/episodes/0300-0399/0344.yaml
+++ b/validation/episodes/0300-0399/0344.yaml
@@ -1,0 +1,172 @@
+episode: 344
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_announced:
+    - name: "Петя"
+      identified_as: PetrDidenko
+      announced_at_sec: 29.84
+    - name: "гость Андрей из Mirantis"
+      identified_as: SPEAKER_04
+      announced_at_sec: 80.67
+  total_duration_sec: 7780  # ~2 часа 10 минут
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "PetrDidenko"
+    total_duration_sec: 741
+    replies_count: 197
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "petr_didenko"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "В начале (29.84s) Umputun представляет: 'Во-первых, Петя. Петр, здравствуй'. Далее обращается к нему по имени."
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 498
+    replies_count: 103
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: null
+      identification_method: "introduction"
+      confidence: high
+      evidence: "В 120.9s представляется: 'Меня зовут Андрей. Я в Москве нахожусь. Компания Mirantis. Мы занимаемся... OpenStack.' Гость пришёл рассказать про FuelWeb."
+
+      guest_info:
+        name: "Андрей"
+        company: "Mirantis"
+        topic: "OpenStack, FuelWeb"
+        note: "Пришёл по собственной инициативе, не от маркетинга компании"
+
+      possible_matches: []
+
+      voice_task:
+        needed: true
+        reason: "Нужно создать запись в people.yaml для идентификации в других эпизодах"
+        reference_segment:
+          stime: 305.45
+          etime: 320.18
+          duration_sec: 14.73
+          text: "исторически сложилось, что нам это надо часто делать, поэтому мы стали разрабатывать удобные инструментарии, потому что действительно OpenStack очень тяжело развертывать руками на стану, допустим, надо на каждую зайти, и даже если скриптик, все равно это грустно."
+        alternate_segment:
+          stime: 151.54
+          etime: 162.87
+          duration_sec: 11.33
+          text: "И все мое общение с нашим любимым шоу и его ведущими началось вчера. И сегодня благополучно закончилось тем, что я присутствую сейчас на онлайн-трансляции, за что огромнейшее спасибо."
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 62
+    replies_count: 14
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "eldar_murtazin"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Эльдар Муртазин — регулярный гость подкаста (86 выпусков).
+        В соседних выпусках (340, 345) также присутствует с большим количеством реплик.
+        Однако в этом выпуске:
+        - НЕ был представлен в начале (только Петя и гость Андрей)
+        - Реплики разбросаны (scattered pattern)
+        - Малое количество реплик (14) по сравнению с другими выпусками (29-63)
+
+        Возможные объяснения:
+        1. Подключился позже без формального представления (типично для регулярных гостей)
+        2. Частичная ошибка атрибуции — некоторые реплики могут принадлежать ведущим
+
+      possible_matches:
+        - person_id: "eldar_murtazin"
+          confidence: 0.7
+          reason: "Регулярный участник, похожий стиль комментариев"
+        - person_id: null  # ошибка атрибуции
+          confidence: 0.3
+          reason: "Не был представлен, реплики разрозненные"
+
+      voice_task:
+        needed: true
+        reason: "Подтвердить, что это действительно Эльдар, а не ошибка атрибуции ведущих"
+        reference_segment:
+          stime: 3060.12
+          etime: 3065.97
+          duration_sec: 5.85
+          text: "Я на самом деле жду, что они вот чего-то сделают с MacBook, потому что очень как-то не хочется."
+        alternate_segment:
+          stime: 6848.69
+          etime: 6858.15
+          duration_sec: 9.46
+          text: "Короче, суть сводится к тому, что доступ к продукту имеют только платные подписчики, а только через некоторое время код передается в публичный доступ."
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 0.22
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Одна короткая реплика 'Ну-ну' (0.22 сек) в 7652s между репликами Bobuk — явная ошибка распознавания речи"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.8
+          reason: "Реплика окружена репликами Bobuk (7650-7652, затем 7655-7661), вероятно его же голос"
+
+      voice_task:
+        needed: false
+        reason: "Слишком короткая реплика для анализа (0.22 сек)"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "EldarMurtazin"
+      issue: "Не был представлен в начале выпуска. Возможно подключился позже или ошибка атрибуции."
+    - speaker: "SPEAKER_04"
+      issue: "Идентифицирован как Андрей из Mirantis, но нет записи в people.yaml"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 344
+    from_speaker: "SPEAKER_05"
+    to_speaker: "Bobuk"
+    confidence: medium
+    reason: "Короткая реплика 'Ну-ну' между репликами Bobuk, вероятная ошибка сегментации"
+
+  - type: add_person
+    person_id: "andrey_mirantis"
+    canonical_name: "AndreyMirantis"
+    aliases: []
+    real_name: "Андрей"
+    info: "Mirantis, OpenStack/FuelWeb, выпуск 344"
+    note: "Требуется поиск фамилии и проверка других эпизодов"
+
+# Задачи требующие ручной проверки
+manual_review_tasks:
+  - task: "voice_comparison"
+    speaker: "EldarMurtazin"
+    description: "Сравнить голос с эталонным выпуском (напр. 345) для подтверждения идентификации"
+    priority: medium
+
+  - task: "identify_full_name"
+    speaker: "SPEAKER_04"
+    description: "Найти полное имя Андрея из Mirantis (возможно в блогах, LinkedIn, или других источниках о FuelWeb 2013)"
+    priority: low

--- a/validation/episodes/0300-0399/0345.yaml
+++ b/validation/episodes/0300-0399/0345.yaml
@@ -1,0 +1,256 @@
+episode: 345
+status: needs_review
+analyzed_at: "2026-01-25T12:00:00Z"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Marin_k_a, EldarMurtazin]
+  total_duration_sec: 8117  # ~2h 15m
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  # SPEAKER_06 - явно Ksenks (Ксюша)
+  - speaker: "SPEAKER_06"
+    total_duration_sec: 365
+    replies_count: 150
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. Umputun прямо обращается "Ксюша, как? Почему?" (26-27s)
+        2. Говорит про "берег океана" в Сан-Франциско - была на WWDC
+        3. Bobuk: "осталась без мужа" - шутка про отсутствие Umputun
+        4. В конце: "Ксюша, вот просто она не даст соврать" (8040s)
+        5. Стиль речи и контекст соответствуют ведущей Ksenks
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  # SPEAKER_01 - гость Алекс (Alexmak)
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 689
+    replies_count: 128
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "alexmak"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. Umputun: "У меня жена спросила, а кто такой этот Алекс, который придет?" (68-71s)
+        2. Описание: "человек, который работает на работе, а в виде хобби ходит везде и рассказывает, какой Apple прекрасный" (72-79s)
+        3. В конце: "И один гость в лице Алекса, которого вы по голосу узнали на общественных началах Евангелиста" (8101-8108s)
+        4. SPEAKER_01: "мне на самом деле Тим Кук ежедневно перечисляет свежими айфонами" (84s) - ироничный ответ
+        5. Обращения "Алекс" по тексту: 1162s, 3052s, 4276s, 12610s, 18046s
+        6. Упоминание блога и работы не в Apple: "Это одна из причин, по которой я в Apple не работаю" (8075s)
+        7. Alexmak - известный русскоязычный блогер про Apple
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  # SPEAKER_00 - вероятно ошибка распознавания ведущего
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 30
+    replies_count: 8
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Реплики разбросаны по эпизоду (3174s, 3522s, 4005s, 4239s, 4405s, 4465s).
+        Стиль речи типичен для ведущих:
+        - "Это вот как ты, Женя..." - обращение по имени к Umputun
+        - "Слушай, это вам на конференции..." - фамильярный тон
+        - "Представляете..." - риторический вопрос
+        - "Всем мы, товарищи, Яндекса и поздравляем" - шутка про Яндекс (Bobuk/Gray работают там)
+        Вероятно это Bobuk или Gray с плохим распознаванием голоса.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.6
+          reason: "Фамильярный стиль, шутки про Яндекс, обращение к Женя"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Тоже работает в Яндексе, мог быть неверно распознан"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3522.92
+          etime: 3531.01
+          text: "Слушай, это вам на конференции просто подкладывали в еду материалы соответствующие, вот оно подействовало."
+
+  # SPEAKER_07 - артефакт распознавания
+  - speaker: "SPEAKER_07"
+    total_duration_sec: 2
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Всего 2 реплики (<2 сек каждая):
+        - 2582s: "Очень девочка моя, Титя, да?" - бессмысленная фраза, вероятно артефакт
+        - 2909s: "Угу" - односложная реакция
+        Типичный паттерн ошибок распознавания.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  # SPEAKER_05 - артефакт в конце
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одна реплика в самом конце эпизода (7461s):
+        "Рок-н-ролл и отличные" - обрезанная фраза, вероятно часть заставки или артефакт.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  # SPEAKER_MISATTRIBUTED_PETR - ранее ошибочно приписано PetrDidenko
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 6
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Реплики были ошибочно приписаны PetrDidenko, но он не участвовал в выпуске.
+        Короткие фразы (691s, 3911s, 5173s): "Что нужно сделать?", "Он уже год...", "Я просто не верил".
+        Вероятно это один из ведущих или гость Алекс.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "alexmak"
+          confidence: 0.4
+          reason: "Может быть Алекс, учитывая тематику Apple"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Мог быть один из ведущих"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3911.17
+          etime: 3915.26
+          text: "Он уже год, почти год не в продаже находится."
+
+  # SPEAKER_MISATTRIBUTED_LAVALE - ранее ошибочно приписано Lavale
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 7
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одна реплика (3682s) о WebOS была ошибочно приписана Lavale.
+        Lavale не участвовала в этом выпуске.
+        По контексту (обсуждение WebOS и iOS 7) - вероятно это Marin_k_a или Alexmak.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Marin_k_a участвует в выпуске и говорит в соседних репликах"
+        - person_id: "alexmak"
+          confidence: 0.4
+          reason: "Алекс тоже обсуждает iOS активно"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3682.03
+          etime: 3688.54
+          text: "Люди, например, которые у меня знакомые, которые раньше пользовались WebOS, им, например, в каких-то моментах действительно она напоминает."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "SPEAKER_00"
+      issue: "8 реплик неизвестного спикера - вероятно ошибка распознавания ведущего"
+    - speaker: "SPEAKER_MISATTRIBUTED_*"
+      issue: "4 реплики ранее ошибочно атрибутированы PetrDidenko и Lavale"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 345
+    from_speaker: "SPEAKER_06"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Явное представление: Umputun обращается 'Ксюша', она была на WWDC"
+
+  - type: rename
+    episode: 345
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Alexmak"
+    confidence: high
+    reason: "Явное представление: 'гость Алекс', Apple евангелист с блогом"
+
+  - type: delete
+    episode: 345
+    from_speaker: "SPEAKER_07"
+    to_speaker: null
+    confidence: high
+    reason: "Артефакт распознавания - бессмысленные фразы"
+
+  - type: delete
+    episode: 345
+    from_speaker: "SPEAKER_05"
+    to_speaker: null
+    confidence: high
+    reason: "Артефакт - обрезанная фраза в конце эпизода"
+
+# Примечания для ручной проверки
+notes: |
+  1. SPEAKER_06 -> Ksenks - уверенность HIGH, можно применять автоматически
+  2. SPEAKER_01 -> Alexmak - уверенность HIGH, можно применять автоматически
+  3. SPEAKER_00 - требует voice comparison с Bobuk/Gray
+  4. SPEAKER_MISATTRIBUTED_* - требует voice comparison
+  5. В выпуске упоминается "Олег" (64s) - это тоже Alexmak (по контексту это то же лицо)
+
+  Дата выпуска: 22 июня 2013 (из транскрипта)
+  Тема: WWDC 2013, iOS 7, Mac Pro

--- a/validation/episodes/0300-0399/0346.yaml
+++ b/validation/episodes/0300-0399/0346.yaml
@@ -1,0 +1,238 @@
+episode: 346
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [Ksenks, Marin_k_a]
+  total_duration_sec: 7815  # ~2h 10min
+  note: "В начале Umputun говорит 'в составе из троих гадов' - это Umputun, Bobuk, Ksenks. Marin_k_a также участвует активно."
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 672
+    replies_count: 275
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Множество прямых доказательств:
+        1. В начале (10-28s) Umputun говорит "насколько заканчивается, Маруся?" - SPEAKER_01 отвечает
+        2. Umputun: "Маруся – это между Оксаной и Ксюшей по степени унижения" (18-22s)
+        3. SPEAKER_01: "Я же Оксаной должна быть по ГОСТу" (15-18s)
+        4. Umputun: "номер Оксаны Ксюша сказала" (28-32s)
+        5. Позже (5112s): Umputun: "Вот в этом стандарте, Ксюшенька, положено так"
+        6. В конце (7729s): "Ксюшенька, а ты про что будешь?" - SPEAKER_01 отвечает "Ох, я не знаю"
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 537
+    replies_count: 103
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "existing_label"
+      confidence: high
+      evidence: "Уже корректно размечена как Marin_k_a. Это бывшая ведущая Марина, активно участвует в обсуждениях."
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "Gray"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Gray не был объявлен участником выпуска. Umputun в начале говорит "в составе из троих гадов"
+        (Umputun, Bobuk, Ksenks). Единственная реплика "Умпутуновскую" (7664s) - короткое слово,
+        вероятно ошибка распознавания другого участника.
+      identified_as: null
+      confidence: null
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Ksenks активно участвует, короткая реплика могла быть её"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Bobuk также активен в этом сегменте"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 7664.03
+          etime: 7665.33
+          text: "Умпутуновскую."
+          note: "Слишком короткий сегмент для надёжного сравнения"
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 5
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Две разрозненные реплики в разных частях выпуска:
+        1. "Какие еще самые такие частые?" (3445s) - уточняющий вопрос
+        2. "Пошел хорошо." (7806s) - реакция на коньяк в конце
+        Суммарно <5 сек, случайные моменты - типичный паттерн ошибок распознавания.
+      identified_as: null
+      confidence: null
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "SPEAKER_01 (Ksenks) активна, могла быть ошибочно сегментирована"
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "Marin_k_a также активна в выпуске"
+      voice_task:
+        needed: false
+        note: "Сегменты слишком короткие для voice comparison"
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 0.26
+    replies_count: 2
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Две последовательные микро-реплики (<0.2 сек каждая):
+        - "А AMQP, Женя?" (5106.75-5106.93s)
+        - "AMQP, да?" (5106.95-5107.03s)
+        Обращение "Женя" к Umputun указывает на кого-то из ведущих/участников.
+        Сразу после Umputun отвечает Ksenks: "Ксюшенька, положено так".
+        Вероятно это была реплика Ksenks, ошибочно сегментированная.
+      identified_as: null
+      confidence: null
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: "Обращается к Umputun как 'Женя', сразу после этого Umputun отвечает Ksenks"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Также могла обратиться по имени"
+      voice_task:
+        needed: false
+        note: "Сегмент слишком короткий (0.26 сек)"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 3
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Реплика "Я про что-нибудь тоже могу рассказать" (7732s) идёт сразу после диалога:
+        - Umputun: "Ксюшенька, а ты про что будешь?"
+        - SPEAKER_01 (Ksenks): "Ох, я не знаю"
+        - [эта реплика]
+        Контекст указывает на продолжение разговора между ведущими. Lavale не упоминается в выпуске.
+        Уже помечено как MISATTRIBUTED, что правильно.
+      identified_as: null
+      confidence: null
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "Продолжение диалога с Ksenks"
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "Могла включиться в разговор"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 7732.79
+          etime: 7735.31
+          text: "Я про что-нибудь тоже могу рассказать."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 2
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Две короткие реплики в разных частях выпуска:
+        1. "А зачем сразу выкладывать на YouTube?" (1870s) - в диалоге о Google Hangouts
+        2. "Что вы хотели сказать-то?" (4654s) - после Bobuk: "Евгений, давайте ближе к теме"
+        Eldar Murtazin не участвовал в выпуске 346. Уже помечено как MISATTRIBUTED.
+      identified_as: null
+      confidence: null
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "SPEAKER_01 активно обсуждает Google+ в этом сегменте"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Может быть реплика Bobuk"
+      voice_task:
+        needed: false
+        note: "Реплики слишком короткие"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Реплика "Короче, про группы ты меня нифига не убедил" (2277s) в споре о Google+.
+        Контекст: Umputun и Bobuk спорят про Google+, реплика похожа на стиль Bobuk.
+        Petr Didenko не участвовал в выпуске 346. Уже помечено как MISATTRIBUTED.
+      identified_as: null
+      confidence: null
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.6
+          reason: "Стиль и контекст соответствуют Bobuk в споре про Google+"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Может быть реплика Umputun"
+      voice_task:
+        needed: false
+        note: "Реплика слишком короткая"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Gray"
+      issue: "Gray не объявлен участником, но имеет 1 реплику. В начале Umputun говорит 'троих гадов' (без Gray)."
+    - speaker: "SPEAKER_01"
+      issue: "Должен быть переименован в Ksenks - есть прямые доказательства идентификации"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 346
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Множество прямых доказательств: обращения 'Маруся', 'Ксюша', 'Ксюшенька' от Umputun"
+
+  - type: investigate
+    episode: 346
+    speaker: "Gray"
+    confidence: medium
+    reason: "Gray не участвовал в выпуске по объявлению ведущего. Требуется voice comparison."
+
+  - type: merge_to_unknown
+    episode: 346
+    from_speakers: ["SPEAKER_00", "SPEAKER_04"]
+    reason: "Микро-сегменты (<5 сек), ошибки распознавания. Нужно определить кому принадлежат."

--- a/validation/episodes/0300-0399/0347.yaml
+++ b/validation/episodes/0300-0399/0347.yaml
@@ -1,0 +1,205 @@
+episode: 347
+status: needs_review
+analyzed_at: "2025-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Marin_k_a]  # Марина, бывшая ведущая - уже идентифицирована в people.yaml
+  total_duration_sec: 7556  # примерная длительность по последним таймкодам
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 210
+    replies_count: 96
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "В 86.4s Umputun обращается: 'Ксюша, у тебя в паспорте не написано что-нибудь такого...', затем в 91.14s SPEAKER_01 отвечает: 'Укор не написано.'"
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 387
+    replies_count: 85
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: "Уже идентифицирована в people.yaml как Марина, бывшая ведущая. Активно участвует в диалоге с первых минут."
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 48
+    replies_count: 10
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Это отменённая ошибочная атрибуция Эльдару Муртазину. Реплики разбросаны по эпизоду между репликами известных ведущих. Скорее всего это ошибки распознавания одного из ведущих (Bobuk или Gray)."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Технические темы (телевизоры, Rust), стиль речи похож"
+        - person_id: "gray"
+          confidence: 0.4
+          reason: "Некоторые реплики в контексте его высказываний"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 7259.75
+          etime: 7264.91
+          text: "Честно говоря, я не очень понимаю, как это зарелизился 0.7."
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 15
+    replies_count: 6
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "6 коротких реплик (1-5 сек) разбросаны по эпизоду: 'А то все выпускают', 'Ага, понятно', 'Я не помню', 'По-моему, да...', 'А дальше?', 'Не знаю по какой'. Типичные ошибки распознавания коротких фраз ведущих."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Часть реплик может быть Ксенией, особенно короткие реакции"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Некоторые реплики в контексте диалогов Gray"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5184.92
+          etime: 5192.87
+          text: "По-моему, да, мы решили, что нужно понизить градус гикивости. А дальше?"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Одна реплика 'Контрол-зе, а потом делаешь... Я долго выходил из Вима, Бабук.' — обращение к Бобуку, значит это не Бобук и не Пётр Диденко. Ошибка атрибуции."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.6
+          reason: "Обращается к Бабуку, сразу после него Umputun продолжает тему Vim"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Также мог участвовать в обсуждении Vim"
+
+      voice_task:
+        needed: false
+        reference_segment: null  # Слишком короткая реплика (2 сек) для voice comparison
+
+  - speaker: "SPEAKER_06"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Реплика 'Продолжение следует...' в 3318s — это рекламный голос/джингл. Сразу после Bobuk комментирует: 'Господи, как я люблю эти рекламные голоса'. Должен быть SPEAKER_99 или _ad."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "SPEAKER_01"
+      issue: "Должен быть переименован в Ksenks. В начале эпизода Umputun обращается к 'Ксюше', и SPEAKER_01 отвечает."
+    - speaker: "SPEAKER_06"
+      issue: "Рекламный голос/джингл, должен быть SPEAKER_99 или _ad"
+    - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+      issue: "10 реплик неизвестного происхождения. Требуется voice comparison или ручная проверка."
+    - speaker: "SPEAKER_00"
+      issue: "6 коротких реплик — вероятно ошибки распознавания разных ведущих"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 347
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Umputun обращается к 'Ксюше' в 86.4s, SPEAKER_01 отвечает в 91.14s. 96 реплик, 210 сек."
+
+  - type: rename
+    episode: 347
+    from_speaker: "SPEAKER_06"
+    to_speaker: "SPEAKER_99"
+    confidence: high
+    reason: "Рекламный голос 'Продолжение следует...' — Bobuk сразу комментирует 'как я люблю эти рекламные голоса'"
+
+  - type: review_needed
+    episode: 347
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: null
+    confidence: low
+    reason: "10 реплик, 48 сек. Требуется voice comparison — возможно Bobuk или Gray"
+
+  - type: review_needed
+    episode: 347
+    from_speaker: "SPEAKER_00"
+    to_speaker: null
+    confidence: low
+    reason: "6 коротких реплик (1-5 сек), разбросаны по эпизоду. Вероятно ошибки распознавания"
+
+  - type: review_needed
+    episode: 347
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    to_speaker: "Umputun"
+    confidence: medium
+    reason: "Реплика про Vim с обращением к Бабуку. Umputun сразу продолжает тему."

--- a/validation/episodes/0300-0399/0348.yaml
+++ b/validation/episodes/0300-0399/0348.yaml
@@ -1,0 +1,164 @@
+episode: 348
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray, Bobuk]
+  guests_present: [Marin_k_a, EldarMurtazin]
+  total_duration_sec: 9249
+
+# Примечание: Bobuk имеет только 7 реплик (18 сек) - возможно присоединился ненадолго
+# EldarMurtazin подтверждён фразой "Сегодня у Маринки день рождения" (4611s)
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 401
+    replies_count: 142
+    pattern: consecutive  # чередуется с Marin_k_a подряд
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. Говорит в женском роде: "я отстала" (770.4s), "я-то думала" (662.3s)
+        2. Чередуется с Marin_k_a буквально подряд в одном диалоге (см. 716-773s)
+        3. EldarMurtazin упоминает "Сегодня у Маринки день рождения" (4611.4s)
+        4. Тематическое продолжение мыслей Marin_k_a
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 10
+    replies_count: 7
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.6
+          reason: "Говорит в женском роде 'Я поняла' (6668.7s), но Marin_k_a уже размечена отдельно"
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Контекст обращения к 'Ксюша'/'Ксюшенька' перед репликами (1194s, 6656s)"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6666.9
+          etime: 6669.2
+          text: "Да, можно сломать запуск. Я поняла."
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 2
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие реплики (2 сек), вероятно ошибка распознавания одного из ведущих"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Контекст обсуждения Горбачёва, Gray активен в этот момент"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Marin_k_a активна в эпизоде"
+
+      voice_task:
+        needed: false
+        reference_segment: null  # слишком короткие реплики для сравнения
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Единственная реплика 1 сек - скорее всего ошибка распознавания"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Реплика 'Почему фиг вам?' (6067.2s) - реакция на Umputun"
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: false  # уже помечено как спорное
+      error_reason: null
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Единственная реплика 'Чего было не так в базе?' (8897.9s) в контексте обсуждения Google Buzz"
+
+      possible_matches:
+        - person_id: "petr_didenko"
+          confidence: 0.3
+          reason: "Метка MISATTRIBUTED_PETR указывает на предыдущее ошибочное присвоение"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 8897.9
+          etime: 8899.7
+          text: "Чего было не так в базе?"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Marin_k_a"
+      issue: "Не представлена явно в начале, но идентифицируется по контексту (день рождения)"
+    - speaker: "EldarMurtazin"
+      issue: "Не представлен явно в начале, но активно участвует с 162s"
+    - speaker: "Bobuk"
+      issue: "Только 7 реплик за весь эпизод - возможно присоединился ненадолго или ошибка разметки"
+    - speaker: "SPEAKER_03"
+      issue: "Неидентифицированный спикер с женским родом речи"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 348
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Marin_k_a"
+    confidence: high
+    reason: |
+      SPEAKER_04 говорит в женском роде и чередуется с Marin_k_a подряд.
+      142 реплики SPEAKER_04 явно принадлежат той же женщине, что и 103 реплики Marin_k_a.
+      Подтверждение: EldarMurtazin говорит "Сегодня у Маринки день рождения" (4611.4s).

--- a/validation/episodes/0300-0399/0349.yaml
+++ b/validation/episodes/0300-0399/0349.yaml
@@ -1,0 +1,238 @@
+episode: 349
+status: has_tasks
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Ksenks]
+  guests_present: []
+  total_duration_sec: 7960
+  notes: |
+    В конце эпизода (7944s) Umputun прямо говорит: "не Оксана, не Маринка и даже
+    не Аляпка, а наоборот – Ксения". Это подтверждает, что в этом выпуске
+    участвовала только Ксения из женщин-ведущих.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 346
+    replies_count: 158
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. В 22-24s SPEAKER_05 отвечает на вопрос Umputun о номере выпуска,
+           Bobuk в 38s говорит "Ксюша сказала, что это число у нее на стеке"
+        2. В 137-143s Umputun спрашивает "Ксюшенька, видел ли ты поверхность...",
+           SPEAKER_05 отвечает "Ну, я видела тоже эту поверхность"
+        3. Весь эпизод ведущие обращаются к "Ксюша/Ксюшенька" и SPEAKER_05 отвечает
+        4. Женский род в ответах ("видела", "стеке")
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 608
+    replies_count: 105
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: |
+        КРИТИЧЕСКАЯ ОШИБКА: В конце эпизода (7944s) Umputun прямо говорит:
+        "не Оксана, не Маринка и даже не Аляпка, а наоборот – Ксения".
+        Это подтверждает, что Марина НЕ участвовала в этом выпуске.
+        Все реплики Marin_k_a должны быть Ksenks.
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Прямая цитата в 7944s: "не Маринка... а наоборот – Ксения"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 36
+    replies_count: 15
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие (1-4 сек) разрозненные реплики по всему эпизоду.
+        Типичные фразы: "Расслабляет, нет?", "Может, голубым?", "Да.", "Нет."
+        Похоже на ошибки распознавания голоса одного из ведущих.
+        В выпуске 349 участвовали только Umputun, Bobuk и Ksenks.
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Некоторые реплики по стилю похожи на Bobuk"
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Мог быть женский голос (Ksenks)"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 7720.76
+          etime: 7724.96
+          text: "Слушай, ну они же сейчас купили этот. Рекламу им дали."
+        notes: |
+          Самый длинный непрерывный сегмент SPEAKER_04.
+          Нужно сравнить с голосами Bobuk, Umputun и Ksenks.
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 0
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика (3836.77s): "Нет, это ГААС."
+        Это дубль реплики Umputun (3835.87s): "Нет, это ГААС."
+        Полностью совпадает текст и перекрывается время — ошибка распознавания.
+      identified_as: "umputun"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Строка 9430-9442: Umputun говорит "Нет, это ГААС" в 3835.87s,
+        затем SPEAKER_03 говорит то же самое "Нет, это ГААС" в 3836.77s.
+        Это один человек, двойное распознавание.
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная короткая реплика (5199.3s): "Что сейчас было про это рассказывать?"
+        Эльдар Муртазин не участвовал в этом выпуске. MISATTRIBUTED означает,
+        что это уже была помечена как ошибочная атрибуция.
+        Скорее всего это кто-то из ведущих (Bobuk, Umputun или Ksenks).
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "По стилю вопроса похоже на Bobuk"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5199.29
+          etime: 5201.07
+          text: "Что сейчас было про это рассказывать?"
+        notes: |
+          Реплика между Bobuk и Umputun. Нужно сравнить голос.
+
+  - speaker: "Gray"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика Gray за весь 2+ часовой выпуск: "В Digital Cloud" (5921.62s).
+        В конце выпуска (7944s) Umputun перечисляет участников: только Ксения.
+        Gray явно не участвовал в этом выпуске.
+        Скорее всего это ошибка распознавания голоса Bobuk или Umputun.
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.5
+          reason: "Контекст диалога: Umputun говорит до и после"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Возможная ошибка распознавания"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5921.62
+          etime: 5922.86
+          text: "В Digital Cloud."
+        notes: |
+          Нужно сравнить с голосами Umputun и Bobuk.
+          SPEAKER_99 сразу после говорит "Digital Ocean" — возможно коррекция.
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Gray"
+      issue: |
+        Gray размечен с 1 репликой, но в конце эпизода Umputun говорит что
+        участвовала только Ксения. Gray не участвовал в этом выпуске.
+    - speaker: "Marin_k_a"
+      issue: |
+        105 реплик размечены как Marin_k_a, но Umputun прямо говорит
+        "не Маринка... а Ксения". Все реплики Marin_k_a — это Ksenks.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 349
+    from_speaker: "SPEAKER_05"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      SPEAKER_05 отвечает когда обращаются к "Ксюша/Ксюшенька".
+      Bobuk в 38s говорит "Ксюша сказала" после реплики SPEAKER_05.
+
+  - type: rename
+    episode: 349
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      КРИТИЧЕСКОЕ: Umputun в конце эпизода (7944s) прямо говорит
+      "не Маринка... а наоборот – Ксения". Марина не участвовала.
+
+  - type: delete
+    episode: 349
+    from_speaker: "SPEAKER_03"
+    to_speaker: null
+    confidence: high
+    reason: |
+      Дубль реплики Umputun. Одинаковый текст "Нет, это ГААС"
+      в перекрывающееся время (3835-3837s).
+
+  - type: rename
+    episode: 349
+    from_speaker: "Gray"
+    to_speaker: "SPEAKER_UNIDENTIFIED_349_01"
+    confidence: medium
+    reason: |
+      Gray не участвовал в эпизоде 349 (подтверждено в конце).
+      Требуется voice comparison для определения реального спикера.
+
+# Аудио для voice comparison
+audio_url: null
+notes: |
+  Нужно получить URL аудио из data/349/349_desc.json (файл не найден в data_clean).
+
+  Основные находки:
+  1. Marin_k_a — КРИТИЧЕСКАЯ ОШИБКА, это Ksenks (105 реплик)
+  2. SPEAKER_05 — это Ksenks (158 реплик)
+  3. Gray — ошибка, Gray не участвовал (1 реплика)
+  4. SPEAKER_03 — дубль Umputun, удалить (1 реплика)
+  5. SPEAKER_04 — ошибки распознавания, нужен voice comparison (15 реплик)
+  6. SPEAKER_MISATTRIBUTED_ELDAR — ошибка, нужен voice comparison (1 реплика)

--- a/validation/episodes/0300-0399/0350.yaml
+++ b/validation/episodes/0300-0399/0350.yaml
@@ -1,0 +1,250 @@
+episode: 350
+status: needs_review
+analyzed_at: "2026-01-25T12:00:00Z"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray, Bobuk]
+  guests_present: [Marin_k_a, EldarMurtazin]
+  total_duration_sec: 7541  # ~2 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_07"
+    total_duration_sec: 444
+    replies_count: 149
+    pattern: consecutive
+    analysis:
+      is_error: false
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. Umputun говорит "пришла Ксюша" (12.2s), SPEAKER_07 сразу отвечает (25.6s)
+        2. Umputun обращается к "Ксюшенька" и SPEAKER_07/Marin_k_a чередуются в ответах
+        3. Женский голос, участвует как постоянный ведущий
+        4. Реплика "В Москве какое-то очень хреновое лето" — московская, как и Ksenks
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_06"
+    total_duration_sec: 15
+    replies_count: 7
+    pattern: scattered
+    analysis:
+      is_error: false
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        1. На вопрос Umputun'а "Ксюшенька, ты знаешь про модели опций?" (1836s)
+           SPEAKER_06 отвечает "Не уверена, что ты имеешь в виду" (1846s)
+        2. Женский голос, говорит "мне баба сказала не ходить"
+        3. Вероятно тот же голос что SPEAKER_07, но другой идентификатор из-за технических причин
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.2
+          reason: "Также женский голос, присутствует в эпизоде"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1846.78
+          etime: 1848.30
+          text: "Не уверена, что ты имеешь в виду."
+        compare_with: "SPEAKER_07 сегмент 25.6-33.9s для сравнения голосов"
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 173
+    replies_count: 25
+    pattern: consecutive
+    analysis:
+      is_error: false
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Реальный гость-слушатель из эфира:
+        - Представился: "Меня зовут Артем" (503.6s)
+        - Работает на "нефтегазовом заводе"
+        - Участвует в обсуждении про сисадминов
+      possible_matches: []
+      voice_task:
+        needed: false
+        note: "Анонимный слушатель, идентификация не требуется"
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 248
+    replies_count: 48
+    pattern: consecutive
+    analysis:
+      is_error: false
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Реальный гость-слушатель из эфира:
+        - Представился как работник ЦЕРНа в Швейцарии (973.5s)
+        - Рассказывает про разделение аникейщиков и сисадминов в ЦЕРНе
+        - Обслуживает эксперимент на Большом Адронном Коллайдере
+      possible_matches: []
+      voice_task:
+        needed: false
+        note: "Анонимный слушатель, идентификация не требуется"
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 8
+    replies_count: 6
+    pattern: consecutive
+    analysis:
+      is_error: true
+      error_reason: "Рекламный/анонсовый аудио-вставка мероприятия 'Рок-АйТи' в Таллинне"
+      identified_as: null
+      evidence: |
+        Все реплики — анонс мероприятия:
+        - "Приглашаем найти события нового формата" (5528s)
+        - "Рок-АйТи" (5531s)
+        - "24 и 25 августа" (5537s)
+        - "Спортхолл Калев. Таллинн" (5540s)
+        - "Бесплатный вход и участие" (5541s)
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 4
+    replies_count: 2
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: "Короткие реплики (<2 сек), вероятно ошибка распознавания. Одна реплика 'Электропочта' дублирует контекст обсуждения."
+      identified_as: null
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Контекст вокруг реплик принадлежит Gray"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Также присутствует в контексте"
+      voice_task:
+        needed: false
+        note: "Слишком короткие сегменты для voice comparison"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: "Ранее ошибочно приписана Lavale, отменено. Короткая одиночная реплика."
+      identified_as: null
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 855
+    replies_count: 141
+    pattern: consecutive
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "known_guest"
+      confidence: high
+      evidence: "Уже идентифицирована в справочнике как бывшая ведущая Марина"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 288
+    replies_count: 54
+    pattern: consecutive
+    analysis:
+      is_error: false
+      identified_as: "eldar_murtazin"
+      identification_method: "known_guest"
+      confidence: high
+      evidence: "Уже идентифицирован в справочнике. Первая реплика — вопрос про Helpdesk (386.9s)"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Ksenks"
+      issue: |
+        Ksenks упоминается в начале как "Ксюша" (12.2s), но её реплики размечены как SPEAKER_07 и SPEAKER_06.
+        В транскрипте отсутствует спикер "Ksenks", хотя она явно присутствует.
+    - speaker: "Bobuk"
+      issue: |
+        Bobuk имеет только 4 реплики (14 сек), первая в 987s. Это нетипично мало для ведущего.
+        Возможно часть его реплик неправильно атрибутирована другим спикерам.
+    - speaker: "SPEAKER_01"
+      issue: "Слушатель-гость Артём не представлен формально в начале, пришёл по ходу эфира (~503s)"
+    - speaker: "SPEAKER_02"
+      issue: "Слушатель из ЦЕРНа не представлен формально, пришёл по ходу эфира (~969s)"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 350
+    from_speaker: "SPEAKER_07"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      SPEAKER_07 — это Ksenks (Ксюша):
+      1. Umputun упоминает "пришла Ксюша" в начале, SPEAKER_07 сразу реагирует
+      2. Говорит про Москву (где живёт Ksenks)
+      3. Участвует как постоянный ведущий на протяжении всего эпизода
+      4. 149 реплик, 444 сек — типичный объём для ведущего
+
+  - type: rename
+    episode: 350
+    from_speaker: "SPEAKER_06"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      SPEAKER_06 отвечает на прямое обращение к Ксюше:
+      Umputun: "Ксюшенька, ты знаешь про модели опций?" (1836s)
+      SPEAKER_06: "Не уверена, что ты имеешь в виду." (1846s)
+      Требуется voice comparison для подтверждения.
+
+  - type: rename
+    episode: 350
+    from_speaker: "SPEAKER_00"
+    to_speaker: "_ad"
+    confidence: high
+    reason: "Рекламный анонс мероприятия 'Рок-АйТи', не человек-участник"
+
+  - type: delete_or_merge
+    episode: 350
+    from_speaker: "SPEAKER_05"
+    confidence: medium
+    reason: "2 коротких реплики (<4 сек), вероятно ошибка распознавания Gray или Umputun"
+
+  - type: keep_as_is
+    episode: 350
+    speaker: "SPEAKER_01"
+    reason: "Реальный гость-слушатель Артём, имя известно, но person_id не нужен"
+
+  - type: keep_as_is
+    episode: 350
+    speaker: "SPEAKER_02"
+    reason: "Реальный гость-слушатель из ЦЕРНа, имя неизвестно, но это реальный участник"
+
+# Примечания
+notes: |
+  Эпизод 350 (27 июля 2013) — юбилейный выпуск с Днём системного администратора.
+
+  Состав:
+  - Ведущие: Umputun, Gray, Bobuk (мало реплик), Ksenks (размечена как SPEAKER_07)
+  - Гости: Marin_k_a (Марина), EldarMurtazin (Эльдар Муртазин)
+  - Слушатели в эфире: Артём (SPEAKER_01), сотрудник ЦЕРНа (SPEAKER_02)
+
+  Основные проблемы:
+  1. Ksenks не размечена своим именем — все её реплики под SPEAKER_07 и частично SPEAKER_06
+  2. У Bobuk подозрительно мало реплик для ведущего
+  3. SPEAKER_00 — реклама, должна быть _ad

--- a/validation/episodes/0300-0399/0351.yaml
+++ b/validation/episodes/0300-0399/0351.yaml
@@ -1,0 +1,308 @@
+episode: 351
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Marin_k_a]
+  total_duration_sec: ~7300  # ~2 часа
+  notes: |
+    Выпуск 351 от 3 августа 2013 года.
+    Umputun в начале говорит "в полном составе" и упоминает Ксюшу.
+    Однако спикер Ksenks не размечен - её реплики, вероятно, записаны как SPEAKER_01.
+    Марина (Marin_k_a) присутствует - бывшая ведущая.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  # === SPEAKER_01: Очень вероятно Ksenks ===
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 196
+    replies_count: 85
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. Umputun упоминает "Ксюша какая-то сегодня с немножко поздним зажиганием" (51-58s)
+        2. Bobuk обращается к ней "Ксюша, ты можешь рассказать..." (228-237s)
+        3. SPEAKER_01 использует женские формы глаголов:
+           - "Я хотела сказать, да, в стиле iOS 7" (144s)
+           - "я решила задать вопрос" (3398s)
+           - "я поняла, что вообще все не знают" (3491s)
+           - "Я посмотрела Хаоса" (5976s)
+        4. Активно участвует в технических обсуждениях как ведущая
+        5. 85 реплик на 196 секунд - характерно для ведущего
+
+      possible_matches: []
+
+      voice_task:
+        needed: false  # Высокая уверенность, контекст достаточен
+
+  # === SPEAKER_05: Скорее всего Gray (ошибка распознавания) ===
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 39
+    replies_count: 31
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие фрагментарные реплики (1-2 сек), разбросанные по эпизоду.
+        Контекст показывает, что это вставки в диалоги между известными ведущими.
+        Вероятно, ошибки распознавания спикера - части реплик Gray или Bobuk.
+        Примеры: "Новый тренд" (1 сек), "А Е6?" (2 сек), "Да" (1 сек), "Ну..." (0.1 сек)
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Короткие реплики в технических дискуссиях, Gray присутствует"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Некоторые реплики близки к стилю Bobuk"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2824.59
+          etime: 2828.31
+          text: "Тут просто используются эластисити и спикабилити."
+        notes: "Самый длинный сегмент SPEAKER_05 (4 сек)"
+
+  # === SPEAKER_00: Реклама/объявление ===
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 8
+    replies_count: 5
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "_ad"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Все реплики - рекламное объявление мероприятия:
+        - "Приглашаем на IT-события нового формата" (4274s)
+        - "24 и 25 августа" (4283s)
+        - "Спортхолл Калев" (4285s)
+        - "Таллинн" (4286s)
+        - "Бесплатный вход и участие" (4286s)
+        Это типичная рекламная вставка.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  # === SPEAKER_02: Короткие вставки, вероятно ошибка ===
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 3
+    replies_count: 2
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Всего 2 коротких реплики (1-2 сек) в одном месте (2820s).
+        "Ну не гибкость" и "Эластичность, да" - это части общего диалога
+        о терминах scalability/elasticity. Скорее всего, ошибка в разделении
+        реплик между Gray, Bobuk или Ksenks.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.4
+          reason: "Gray обсуждал технические термины в этом сегменте"
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Ksenks активно участвовала в обсуждении"
+
+      voice_task:
+        needed: false  # Слишком короткие для надёжного сравнения
+
+  # === SPEAKER_07: Минимальные реплики ===
+  - speaker: "SPEAKER_07"
+    total_duration_sec: 1
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Только 2 односложных реплики: "Угу" (0.1s) и "Нет" (0.4s).
+        Типичные ошибки распознавания - краткие реакции,
+        ошибочно выделенные в отдельного спикера.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: false  # Слишком короткие
+
+  # === SPEAKER_MISATTRIBUTED_LAVALE: Ошибочно присвоено Лаваль ===
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 7
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: false  # Это маркер отменённого присвоения
+      error_reason: null
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Это реплики, которые ранее были ошибочно присвоены Lavale.
+        Маркер SPEAKER_MISATTRIBUTED означает, что присвоение отменено.
+        Реплики (256s и 4138s) требуют переатрибуции.
+        Контекст: технические вопросы про GUI и коммиты.
+        Скорее всего принадлежат одному из ведущих.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Реплики в контексте объяснений для 'не-технарей'"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Марина также участвовала в обсуждении Bootstrap"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 256.97
+          etime: 260.57
+          text: "Ну, то есть, я так понимаю, что это очень связано с GUI, всякие кнопочки там."
+
+  # === SPEAKER_MISATTRIBUTED_ELDAR: Ошибочно присвоено Эльдар ===
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 7
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: false  # Это маркер отменённого присвоения
+      error_reason: null
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Реплики ранее ошибочно присвоены EldarMurtazin.
+        - "Я тут на парочку сайтов посмотрел через Е6" (1062s)
+        - "Поддержка Python 3 из коробки Тебя не интересует?" (7105s)
+        Эльдар Муртазин - мобильный аналитик, не участвовал в этом выпуске.
+        Контекст указывает на одного из ведущих.
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Обсуждение браузера IE6 и Python характерно для Gray"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Umputun также обсуждал Python в этом выпуске"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 7105.93
+          etime: 7109.47
+          text: "Поддержка Python 3 из коробки Тебя не интересует?"
+
+  # === Marin_k_a: Подтверждённая участница ===
+  - speaker: "Marin_k_a"
+    total_duration_sec: 439
+    replies_count: 81
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "registry"
+      confidence: high
+      evidence: |
+        Марина (Marin_k_a) - бывшая ведущая, есть в people.yaml.
+        81 реплика на 439 секунд - полноценное участие в выпуске.
+        Первая реплика на 22s - участвует с самого начала.
+        Контекст подтверждает участие в обсуждениях Bootstrap и других тем.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Ksenks"
+      issue: |
+        Ksенks (Ксюша) упоминается Umputun в начале выпуска ("Ксюша какая-то сегодня..."),
+        но нет реплик с author="Ksenks". Её реплики записаны как SPEAKER_01.
+
+    - speaker: "SPEAKER_01"
+      issue: |
+        85 реплик приписаны SPEAKER_01, но контекст явно указывает на Ksenks.
+        Требуется переименование SPEAKER_01 → Ksenks для этого эпизода.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 351
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      SPEAKER_01 использует женские формы глаголов ("хотела", "решила", "поняла", "посмотрела").
+      К ней обращаются как "Ксюша" (228s, 828s, 929s и др.).
+      Umputun в начале говорит о присутствии Ксюши.
+      Стиль реплик соответствует ведущей.
+
+  - type: rename
+    episode: 351
+    from_speaker: "SPEAKER_00"
+    to_speaker: "_ad"
+    confidence: high
+    reason: |
+      Все 5 реплик SPEAKER_00 - рекламное объявление о мероприятии в Таллинне.
+      Это стандартная рекламная вставка, должна быть маркирована как _ad.
+
+# Задания для ручной проверки
+manual_review_tasks:
+  - task: "Verify SPEAKER_01 = Ksenks"
+    priority: low
+    description: "Высокая уверенность, но можно подтвердить голосом"
+
+  - task: "Identify SPEAKER_MISATTRIBUTED_LAVALE"
+    priority: medium
+    description: "2 реплики требуют атрибуции - вероятно Ksenks или Marin_k_a"
+
+  - task: "Identify SPEAKER_MISATTRIBUTED_ELDAR"
+    priority: medium
+    description: "2 реплики про IE6 и Python - вероятно Gray или Umputun"
+
+  - task: "Review SPEAKER_05 segments"
+    priority: low
+    description: "31 короткая реплика - ошибки распознавания, можно игнорировать или удалить"

--- a/validation/episodes/0300-0399/0352.yaml
+++ b/validation/episodes/0300-0399/0352.yaml
@@ -1,0 +1,190 @@
+episode: 352
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [PetrDidenko, Marin_k_a]
+  total_duration_sec: 7497  # ~2 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "PetrDidenko"
+    total_duration_sec: 922
+    replies_count: 241
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: "petr_didenko"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "В 87.81s Umputun говорит 'Петя, ты скажи что-нибудь на своем национальном языке', и PetrDidenko отвечает 'Калимера' (греческое приветствие). В 106.36s он говорит 'Да, здесь у нас в Греции, ну почти в Греции, на Кипре'. Это Пётр Диденко, известный гость."
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 543
+    replies_count: 142
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: "marin_k_a"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "В 19.83s Umputun обращается 'Оксана, почему опоздала, откуда ты и как до жизни такой дошла?' - и Marin_k_a отвечает про выезд и плохой звук. Это Марина, бывшая ведущая. Позже в 37.56s она говорит 'С нами еще есть Бобок' - ведёт перекличку как соведущая."
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 4
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибка распознавания Gray. Контекст: обсуждение украинского языка. Umputun говорит 'парасолька', затем SPEAKER_05 говорит 'В этом языке. Парасолька.' - это продолжение реплики Gray, который только что говорил по-украински ('А че вот сегодня ржуть?', 'Це мабуть бобук ржет'). После SPEAKER_05 сразу Gray продолжает."
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.9
+          reason: "Контекст украинского языка, Gray только что говорил по-украински"
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_06"
+    total_duration_sec: 16
+    replies_count: 6
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибка распознавания Marin_k_a. Все реплики SPEAKER_06 по контексту принадлежат женщине: 'согласна' (212.4s), 'я тоже писала программу на бумажке' (775.8s), 'у вас весеннее у всех настроение' (6332.7s). В этом эпизоде единственная женщина - Marin_k_a (Марина). Bobuk обращается к ней 'ты' перед репликами SPEAKER_06."
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.95
+          reason: "Женский голос, использует женский род ('согласна', 'писала'), единственная женщина в эпизоде"
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 15
+    replies_count: 6
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Реплики в разных контекстах: (1) 2707-2723s - рекламный блок (IT-событие в Таллинне), чередуется с _ad, это голос диктора рекламы. (2) 5625-5630s - осмысленные реплики про опрос, скорее всего один из ведущих (контекст диалога с Umputun)."
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "_ad"
+          confidence: 0.9
+          reason: "Реплики 2707-2723s - часть рекламного блока"
+        - person_id: "bobuk"
+          confidence: 0.6
+          reason: "Реплики 5625-5630s могут быть Bobuk или другим ведущим"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5625.09
+          etime: 5630.02
+          text: "То есть даже те 21%, которые считают, что этого делать неправильно. Они просто не ответили."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 4
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Одиночная реплика 'Это нормальные пионеры' (3886.8s) между репликами Umputun. Короткая реплика-комментарий. Имя спикера указывает на отменённое присвоение Эльдару, но Эльдар не участвует в этом эпизоде. Скорее всего это реплика одного из ведущих (Bobuk, Gray или PetrDidenko)."
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Короткий комментарий в стиле Bobuk"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Возможно Gray"
+        - person_id: "petr_didenko"
+          confidence: 0.2
+          reason: "Возможно Пётр"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3886.85
+          etime: 3890.59
+          text: "Это нормальные пионеры."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "SPEAKER_05"
+      issue: "2 реплики (4 сек) скорее всего Gray - ошибка распознавания в контексте украинского языка"
+    - speaker: "SPEAKER_06"
+      issue: "6 реплик (16 сек) скорее всего Marin_k_a - женский голос, единственная женщина в эпизоде"
+    - speaker: "SPEAKER_00"
+      issue: "6 реплик в двух контекстах: реклама (4 реплики) и диалог (2 реплики) - требует разделения"
+    - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+      issue: "Одиночная реплика неясного происхождения, Эльдара нет в эпизоде"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 352
+    from_speaker: "SPEAKER_05"
+    to_speaker: "Gray"
+    confidence: high
+    reason: "Контекст украинского языка, Gray только что говорил по-украински, продолжение той же темы"
+
+  - type: rename
+    episode: 352
+    from_speaker: "SPEAKER_06"
+    to_speaker: "Marin_k_a"
+    confidence: high
+    reason: "Женский род в речи ('согласна', 'писала'), единственная женщина в эпизоде - Marin_k_a"
+
+  - type: rename
+    episode: 352
+    from_speaker: "SPEAKER_00"
+    to_speaker: "_ad"
+    time_range: [2707, 2724]
+    confidence: high
+    reason: "Часть рекламного блока, чередуется с уже размеченной рекламой"
+
+# Примечания
+notes: |
+  Эпизод 352 от 10 августа 2013 года.
+  Состав: Umputun, Bobuk, Gray, Marin_k_a (Марина), PetrDidenko (Пётр Диденко с Кипра).
+
+  PetrDidenko и Marin_k_a корректно идентифицированы в транскрипте.
+
+  Основные проблемы:
+  1. SPEAKER_05 (2 реплики) - очевидно Gray по контексту
+  2. SPEAKER_06 (6 реплик) - очевидно Marin_k_a по женскому роду
+  3. SPEAKER_00 - смешаны реклама и возможно один из ведущих
+  4. SPEAKER_MISATTRIBUTED_ELDAR - одиночная неясная реплика

--- a/validation/episodes/0300-0399/0353.yaml
+++ b/validation/episodes/0300-0399/0353.yaml
@@ -1,0 +1,306 @@
+episode: 353
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray, Bobuk]
+  guests_identified: [Marin_k_a]
+  total_hosts_duration_sec: 3448  # Umputun 3293 + Gray 141 + Bobuk 14
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 889
+    replies_count: 205
+    first_appearance_sec: 105
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "viktor_gamov"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "110.4s: 'Да, всем привет, с вами Виктор Гамов, известный также по подкасту Разбор полетов.'"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_07"
+    total_duration_sec: 602
+    replies_count: 107
+    first_appearance_sec: 144
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "alexey_abashov"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "167.8s: 'Меня зовут Абашов Алексей. Я тоже из дружественного подкаста Разбор полетов.'"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_06"
+    total_duration_sec: 532
+    replies_count: 124
+    first_appearance_sec: 227
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "kirill_titov"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "247s: 'Меня зовут Кирилл Титов, я из города-героя Киева... И работаю в одном большом фотостоке.'"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 879
+    replies_count: 160
+    first_appearance_sec: 2377
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "ivan_it_consultant"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "2420s: 'Меня зовут Иван. Я занимаюсь IT-консалтингом. Вытаскиваю разные компании из всяких IT-кризисов.'"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 515
+    replies_count: 193
+    first_appearance_sec: 37
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: >
+        Контекст начала выпуска: Umputun говорит 'Ксюша сказала нагло',
+        затем SPEAKER_01 отвечает. Umputun обращается к Ксюше напрямую,
+        а SPEAKER_01 отвечает. Паттерн совпадает с ведущей Ksenks.
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 471
+    replies_count: 85
+    first_appearance_sec: 67
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "existing_label"
+      confidence: high
+      evidence: "Уже размечена как Marin_k_a (Марина, бывшая ведущая согласно people.yaml)"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 61
+    replies_count: 12
+    first_appearance_sec: 814
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "artem_guest"
+      identification_method: "introduction"
+      confidence: medium
+      evidence: >
+        813.5s: 'Меня зовут Артем. Возможно, меня кто-то по голосу уже узнал, что я тут был.'
+        Гость говорит, что уже был на подкасте ранее. Говорит о Debian и BigBlueButton.
+        Может быть Артём Росновский (был на выпусках 69, 101, 106) но требует voice comparison.
+      possible_matches:
+        - person_id: "artem_rosnovsky"
+          confidence: 0.4
+          reason: "Был на Radio-T ранее, упомянул это. Но нет явного подтверждения имени."
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 827.24
+          etime: 842.68
+          text: "Делали мы сервер сначала OpenMeeting, потом BigBlueButton. Кто не в курсе, это две таких штуковины, которые позволяют делать в локальных сетках такой сервер для видеоконференций."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 56
+    replies_count: 8
+    first_appearance_sec: 479
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Это отменённые присвоения спикера EldarMurtazin.
+        Реплики разбросаны (479s, 3140s, 5409s, 5948s, 6153s, 6263s, 6617s, 6644s).
+        Содержание реплик не соответствует Эльдару - это технические комментарии гостей.
+        Скорее всего это ошибки распознавания других спикеров (возможно гостей из Разбор полетов).
+      identified_as: null
+      possible_matches:
+        - person_id: "viktor_gamov"
+          confidence: 0.3
+          reason: "Некоторые реплики могут принадлежать Гамову по контексту"
+        - person_id: "alexey_abashov"
+          confidence: 0.3
+          reason: "Некоторые реплики могут принадлежать Абашову"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5409.17
+          etime: 5419.47
+          text: "Люди подходят после этой вещи и говорят, слушайте, откуда у вас время нахрен на это все, что вот вы тут все это дело рассказываете и вы вроде еще в этом всем разбираетесь и так далее."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 4
+    replies_count: 2
+    first_appearance_sec: 1016
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Это отменённые присвоения спикера PetrDidenko.
+        Всего 2 коротких реплики (1015s и 1088s) - вероятно ошибки распознавания.
+        Контекст не соответствует Петру Диденко.
+      identified_as: null
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 6
+    replies_count: 4
+    first_appearance_sec: 6112
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Реплики в конце выпуска (6111-6125s): 'Приглашаем найти события нового формата',
+        '24 и 25 августа', 'Таллинн', 'Бесплатный вход и участие'.
+        Это явно рекламное объявление или джингл, должен быть SPEAKER_99 или _ad.
+      identified_as: null
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_08"
+    total_duration_sec: 4
+    replies_count: 2
+    first_appearance_sec: 1687
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Всего 2 короткие реплики: 'Да.' (1687s) и 'Голубой вагон, который пока целый.' (3684s).
+        Разбросаны по времени, короткие - скорее всего ошибки распознавания кого-то из гостей.
+      identified_as: null
+      possible_matches: []
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes: >
+    Выпуск 353 - спецвыпуск с гостями из подкаста "Разбор полетов" (Виктор Гамов, Алексей Абашов)
+    и слушателями (Кирилл Титов, Иван, Артем). Все основные гости представились в начале.
+    Gray появляется с 1129s, Bobuk с 4177s - они присоединились позже.
+    SPEAKER_01 с высокой вероятностью = Ksenks (193 реплики, 515 сек с самого начала).
+  issues:
+    - speaker: "SPEAKER_01"
+      issue: "Не размечен как Ksenks, хотя контекст явно указывает на это (обращения 'Ксюша' от Umputun)"
+    - speaker: "SPEAKER_00"
+      issue: "Рекламный блок/джингл размечен как спикер, должен быть _ad или SPEAKER_99"
+    - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+      issue: "Отменённые присвоения требуют переатрибуции к реальным спикерам"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 353
+    from_speaker: "SPEAKER_05"
+    to_speaker: "ViktorGamov"
+    confidence: high
+    reason: "Явное представление: 'с вами Виктор Гамов, известный также по подкасту Разбор полетов'"
+
+  - type: rename
+    episode: 353
+    from_speaker: "SPEAKER_07"
+    to_speaker: "AlexeyAbashov"
+    confidence: high
+    reason: "Явное представление: 'Меня зовут Абашов Алексей. Я тоже из дружественного подкаста Разбор полетов.'"
+
+  - type: rename
+    episode: 353
+    from_speaker: "SPEAKER_06"
+    to_speaker: "KirillTitov"
+    confidence: high
+    reason: "Явное представление: 'Меня зовут Кирилл Титов, я из города-героя Киева'"
+
+  - type: rename
+    episode: 353
+    from_speaker: "SPEAKER_02"
+    to_speaker: "IvanITConsultant"
+    confidence: high
+    reason: "Явное представление: 'Меня зовут Иван. Я занимаюсь IT-консалтингом.'"
+
+  - type: rename
+    episode: 353
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Контекст: Umputun обращается 'Ксюша', SPEAKER_01 отвечает. 193 реплики с начала выпуска."
+
+  - type: rename
+    episode: 353
+    from_speaker: "SPEAKER_00"
+    to_speaker: "_ad"
+    confidence: high
+    reason: "Рекламный блок: 'Приглашаем найти события нового формата. 24 и 25 августа. Таллинн.'"
+
+  - type: delete
+    episode: 353
+    speaker: "SPEAKER_08"
+    confidence: medium
+    reason: "Короткие разбросанные реплики - ошибки распознавания. Можно слить с ближайшим спикером."
+
+# Гости для добавления в people.yaml
+new_guests_to_add:
+  - id: "viktor_gamov"
+    canonical_name: "ViktorGamov"
+    aliases: ["Виктор", "Гамов"]
+    real_name: "Виктор Гамов"
+    info: "Подкастер, соведущий 'Разбор полетов', выпуск 353"
+
+  - id: "alexey_abashov"
+    canonical_name: "AlexeyAbashov"
+    aliases: ["Алексей", "Абашов"]
+    real_name: "Алексей Абашов"
+    info: "Подкастер, соведущий 'Разбор полетов', выпуск 353"
+
+  - id: "kirill_titov"
+    canonical_name: "KirillTitov"
+    aliases: ["Кирилл", "Титов"]
+    real_name: "Кирилл Титов"
+    info: "Слушатель из Киева, работает в фотостоке, выпуск 353"
+
+  - id: "ivan_it_consultant"
+    canonical_name: "IvanITConsultant"
+    aliases: ["Иван"]
+    real_name: "Иван"
+    info: "IT-консультант, выпуск 353"

--- a/validation/episodes/0300-0399/0354.yaml
+++ b/validation/episodes/0300-0399/0354.yaml
@@ -1,0 +1,223 @@
+episode: 354
+status: clean
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray, Bobuk]
+  guests_present: [Marin_k_a, EldarMurtazin]
+  total_duration_sec: 8230  # ~2.3 hours based on last Eldar reply
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1485
+    replies_count: 388
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "47s: 'у нас сегодня редкая гостья' (Umputun), 49s: 'Я редкая гостья' (Marin_k_a), 67s: 'Это Маруся, конечно, была' (Umputun). Марина - бывшая ведущая подкаста."
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 287
+    replies_count: 52
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      identified_as: "eldar_murtazin"
+      identification_method: "context"
+      confidence: high
+      evidence: "Первая реплика 168s в контексте разговора о ком-то, кто 'летит из Америки'. В 1691s Marin_k_a говорит 'Он на Муртазина похож чем-то' и 'Муртазин хороший' - явное упоминание присутствующего гостя. Эльдар Муртазин - известный мобильный аналитик, частый гость подкаста."
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 369
+    replies_count: 79
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: null
+      identification_method: "introduction"
+      confidence: high
+      evidence: "4979s: Umputun спрашивает 'Роман, ты кто такой?', 4981s: SPEAKER_01 отвечает 'Да, я Роман, я из Литвы, работаю в Barclays, работаю в основном как Unix-инженер'. Это звонок от слушателя."
+
+      possible_matches:
+        - person_id: "roman_from_lithuania"
+          confidence: 1.0
+          reason: "Явное самопредставление: Роман из Литвы, Unix-инженер в Barclays"
+
+      voice_task:
+        needed: false
+        note: "Это звонок слушателя (не постоянный гость), идентификация не требуется"
+
+  - speaker: "SPEAKER_06"
+    total_duration_sec: 9
+    replies_count: 5
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие односложные фразы ('Не знаю даже', 'Так почему?'), разбросанные по выпуску. Вероятно ошибочная атрибуция реплик одного из присутствующих ведущих или гостей."
+
+      identified_as: null
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.6
+          reason: "Реплика 3817s 'Так почему?' идёт после реплики Marin_k_a и перед её следующей репликой - возможно это её слова"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Возможно ошибка распознавания голоса Gray"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5861.95
+          etime: 5865.96
+          text: "Самый длинный сегмент SPEAKER_06 (~4 сек)"
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 9
+    replies_count: 4
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "4 короткие реплики в разных частях выпуска: 'Ух ты' (1633s), 'У Грея глаза голубые' (6489s). Типичные ошибки транскрипции - междометия и случайные фразы."
+
+      identified_as: null
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Реплика 'У Грея глаза голубые' (6489s) появляется в контексте разговора ведущих, следующая реплика - Marin_k_a"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Возможно ошибка распознавания"
+
+      voice_task:
+        needed: false
+        note: "Слишком короткие сегменты для voice comparison (макс ~5 сек)"
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 7
+    replies_count: 5
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "5 очень коротких реплик: 'Почему?' (3776s), 'Это неважно' (4598s). Односложные реакции, типичные для ошибок автоматической транскрипции."
+
+      identified_as: null
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Короткие реплики в контексте диалогов с Marin_k_a"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Возможно ошибка распознавания Gray"
+
+      voice_task:
+        needed: false
+        note: "Слишком короткие сегменты (<2 сек каждый)"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Одна реплика 'И вот не убавить, не прибавить' (5788s). Маркер MISATTRIBUTED указывает на ранее отменённое ошибочное присвоение Петру Диденко. Это реакция на реплику SPEAKER_01 (Романа) об OpenStack."
+
+      identified_as: null
+      possible_matches:
+        - person_id: "roman_from_lithuania"
+          confidence: 0.6
+          reason: "Контекст: это часть разговора со звонящим Романом (SPEAKER_01), скорее всего его реплика"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Предыдущая и последующая реплики - Umputun"
+
+      voice_task:
+        needed: false
+        note: "Одна короткая реплика, недостаточно для идентификации"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes:
+    - "Marin_k_a (Марина) - явно представлена в начале как 'редкая гостья'"
+    - "EldarMurtazin - не представлен явно, но упоминается по фамилии в разговоре (1691s)"
+    - "SPEAKER_01 (Роман) - звонок слушателя, представился сам"
+    - "Bobuk появляется с 1001s - вероятно подключился позже"
+  issues: []
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 354
+    from_speaker: "SPEAKER_01"
+    to_speaker: "CallerRoman"
+    confidence: high
+    reason: "Явное самопредставление: 'Да, я Роман, я из Литвы, работаю в Barclays'"
+
+  - type: merge_or_delete
+    episode: 354
+    speaker: "SPEAKER_06"
+    action: "investigate"
+    confidence: medium
+    reason: "5 коротких реплик, вероятно ошибки атрибуции Marin_k_a или Gray"
+
+  - type: merge_or_delete
+    episode: 354
+    speaker: "SPEAKER_04"
+    action: "investigate"
+    confidence: medium
+    reason: "4 короткие реплики, вероятно ошибки атрибуции"
+
+  - type: merge_or_delete
+    episode: 354
+    speaker: "SPEAKER_03"
+    action: "investigate"
+    confidence: medium
+    reason: "5 очень коротких реплик (<2 сек), вероятно ошибки атрибуции"
+
+  - type: rename_or_delete
+    episode: 354
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    action: "investigate"
+    confidence: medium
+    reason: "Одна реплика, скорее всего принадлежит SPEAKER_01 (Роман) или Umputun"
+
+# Комментарии
+comments: |
+  Эпизод 354 от 24 августа 2013 года.
+
+  Основные участники:
+  - Umputun (ведущий, 1204 реплики)
+  - Gray (ведущий, 326 реплик)
+  - Bobuk (ведущий, подключился позже - с 1001s, 19 реплик)
+  - Marin_k_a (гостья - бывшая ведущая Марина, 388 реплик)
+  - EldarMurtazin (гость - мобильный аналитик, 52 реплики)
+
+  Звонки слушателей:
+  - SPEAKER_01 = Роман из Литвы (Unix-инженер в Barclays), 79 реплик
+
+  Ошибки транскрипции:
+  - SPEAKER_03, SPEAKER_04, SPEAKER_06 - короткие ошибочные атрибуции
+  - SPEAKER_MISATTRIBUTED_PETR - ранее ошибочно приписано Петру Диденко
+
+  Статус: clean - все основные спикеры идентифицированы, оставшиеся
+  неизвестные - это мелкие ошибки транскрипции, не влияющие на качество.

--- a/validation/episodes/0300-0399/0355.yaml
+++ b/validation/episodes/0300-0399/0355.yaml
@@ -1,0 +1,245 @@
+episode: 355
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray, Ksenks]
+  total_duration_sec: 7492
+  notes: |
+    Ksenks участвует в выпуске, но размечена как Marin_k_a (ошибка).
+    Umputun обращается к ней "Ксюша" в 44s, Bobuk также называет её "Ксюша" в 80s.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 830
+    replies_count: 145
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Ошибочная атрибуция. В транскрипте помечена как Marin_k_a (Марина),
+        но по контексту это Ksenks (Ксюша):
+        - 44s: Umputun говорит "Ксюша, доложи нам..." — отвечает Marin_k_a
+        - 80s: Bobuk говорит "...почти что ничего мы не видели, Ксюша"
+        - Нигде в выпуске не упоминается имя "Марина"
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        44s: Umputun: "Ксюша, доложи нам, как мы до жизни такой дошли и вообще?"
+        48s: Marin_k_a отвечает (должна быть Ksenks)
+        80s: Bobuk: "Слушай, почти что ничего мы не видели, Ксюша."
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 498
+    replies_count: 211
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Тот же человек что и Marin_k_a — реплики чередуются без пауз,
+        один и тот же голос продолжает ту же мысль.
+        73s: SPEAKER_01 говорит "И все видели меня почти что" про видео —
+        это продолжение рассказа Ksenks про случайное включение камеры.
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        53s: SPEAKER_01: "То есть одно дело мы уже сделали" — сразу после Marin_k_a
+        73s: SPEAKER_01: "И все видели меня почти что" — про свою камеру
+        92s: SPEAKER_01: "Но второй раз у меня уже получилось..." — продолжение
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 6
+    replies_count: 5
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие реплики в случайных местах — типичные ошибки распознавания:
+        - 1410s: "По-моему, да." (1.5s)
+        - 2540s: "Приложение." (0.6s)
+        - 4416s: "Буткэп ему нужен..." (3s) — возможно Ksenks
+        - 4419s: "Окей, окей, да." (1s)
+        - 7408s: "Про Vertex?" (0.2s)
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "Контекст реплик похож на Ksenks, но слишком короткие для уверенной атрибуции"
+
+      voice_task:
+        needed: false
+        reason: "Реплики слишком короткие для voice comparison"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 7
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Уже помечен как misattributed. Две короткие реплики:
+        - 762s: "Я думаю, что вообще говоря, нет." — между Umputun и Bobuk
+        - 1023s: "По-моему, там только качество..." — между Bobuk и Bobuk
+        Скорее всего один из ведущих, возможно Ksenks или Gray.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Может быть Ksenks, но данных недостаточно"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Может быть Gray"
+
+      voice_task:
+        needed: false
+        reason: "Слишком короткие реплики"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 4
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Уже помечен как misattributed. Две короткие реплики:
+        - 6068s: "Плюс, например, такого нет." — между Marin_k_a и Bobuk
+        - 6689s: "Крайне рекомендую." — между Umputun и Umputun
+        Скорее всего один из ведущих.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Первая реплика сразу после Marin_k_a (=Ksenks)"
+        - person_id: "umputun"
+          confidence: 0.4
+          reason: "Вторая реплика между репликами Umputun"
+
+      voice_task:
+        needed: false
+        reason: "Слишком короткие реплики"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Уже помечен как misattributed. Одна короткая реплика:
+        - 2381s: "Я сейчас активно читаю про него." — между SPEAKER_01 и Umputun
+        Скорее всего Ksenks (SPEAKER_01 = Ksenks).
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: "Реплика сразу после SPEAKER_01 (=Ksenks), продолжение мысли"
+
+      voice_task:
+        needed: false
+        reason: "Слишком короткая реплика"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Marin_k_a"
+      issue: |
+        Размечена как Марина, но в начале выпуска представлена как "Ксюша" (Ksenks).
+        Это серьёзная ошибка атрибуции — 145 реплик присвоены не тому человеку.
+
+    - speaker: "SPEAKER_01"
+      issue: |
+        211 реплик без идентификации, но это тот же человек что Marin_k_a = Ksenks.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 355
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun обращается "Ксюша" в 44s, Bobuk называет "Ксюша" в 80s.
+      Нигде в выпуске не упоминается имя "Марина".
+
+  - type: rename
+    episode: 355
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Реплики SPEAKER_01 чередуются с Marin_k_a без пауз,
+      продолжают ту же мысль. Говорит "у меня" про камеру — это та же Ксюша.
+
+  - type: rename
+    episode: 355
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      Вероятно Ksenks, но реплики слишком короткие для уверенной атрибуции.
+      Рекомендуется voice verification.
+
+  - type: delete_or_merge
+    episode: 355
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: null
+    confidence: low
+    reason: |
+      Требуется ручная проверка — слишком короткие реплики.
+
+  - type: delete_or_merge
+    episode: 355
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    to_speaker: null
+    confidence: low
+    reason: |
+      Требуется ручная проверка — слишком короткие реплики.
+
+  - type: rename
+    episode: 355
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      Реплика идёт сразу после SPEAKER_01 (=Ksenks), продолжает мысль.

--- a/validation/episodes/0300-0399/0356.yaml
+++ b/validation/episodes/0300-0399/0356.yaml
@@ -1,0 +1,46 @@
+episode: 356
+status: clean
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  total_duration_sec: 6983  # ~1358 реплик Umputun + 731 реплик Bobuk
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 0.06
+    replies_count: 1
+    pattern: scattered
+
+    # Результат анализа
+    analysis:
+      is_error: true
+      error_reason: "Одиночное короткое междометие 'Эээ...' длительностью 0.06 сек между репликами Bobuk и Umputun. Типичная ошибка распознавания — реакция одного из ведущих (вероятно Umputun, который отвечает сразу после)."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues: []
+  notes: "Эпизод 356 от 27 сентября 2013 года. В начале Umputun упоминает технические проблемы с записью. Участвуют только два ведущих: Umputun и Bobuk. Гостей нет."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 356
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Umputun"
+    confidence: medium
+    reason: "Короткое междометие 'Эээ...' (0.06 сек) в 4651s непосредственно перед ответом Umputun на вопрос Bobuk. Контекст: Bobuk спрашивает 'Как тебе формулировка?', следует 'Эээ...', затем Umputun отвечает 'А зачем?'. Логически это раздумье Umputun перед ответом."

--- a/validation/episodes/0300-0399/0357.yaml
+++ b/validation/episodes/0300-0399/0357.yaml
@@ -1,0 +1,151 @@
+episode: 357
+status: has_tasks
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_identified: [NikolayDobrovolskiy, AndreyMilinchuk]
+  total_duration_sec: 4941
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 1248
+    replies_count: 238
+    pattern: consecutive
+    first_appearance_sec: 202
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "nikolay_dobrovolskiy"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Bobuk в 56-64s: "Одного зовут Николай Добровольский, он представляется как
+        вице-президент под десктоп-виртуализацией."
+        В 343.6s сам спикер говорит: "Я, Андрей, другие ребята сели, подумали..." -
+        упоминает Андрея как другого человека, значит это Николай.
+        Основной докладчик по продукту Parallels Access.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 383
+    replies_count: 62
+    pattern: consecutive
+    first_appearance_sec: 90
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "andrey_milinchuk"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Bobuk в 65-88s: "А еще у нас есть Андрей Милинчук... Он вообще называется
+        директор по разработке компании Parallels... А вот директор по разработке,
+        он чем занимается?"
+        Первая реплика SPEAKER_00 в 90s - прямой ответ на этот вопрос:
+        "Реально я достаточно долго занимался проект-менеджментом нашего основного
+        продукта Parallels Desktop for Mac, и последние, скажем, два года я как раз
+        занимаюсь нашим новым продуктом... Parallels XS."
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 10
+    replies_count: 2
+    pattern: scattered
+    first_appearance_sec: 4600
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Ошибочная атрибуция. Эпизод 357 не содержит Эльдара Муртазина как гостя.
+        Гости от Parallels (SPEAKER_00/01) закончили говорить к 3447s.
+        Эти реплики появляются в 4600s в контексте обсуждения Apple между ведущими.
+        По содержанию и контексту это реплики Gray - он продолжает тему iPod/iOS.
+
+      identified_as: "gray"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Реплика 4600s: "Ты просто не помнишь, видимо, как апгрейдилось iOS, по-моему, 2 на iPod Touch"
+        Сразу после - реплика Gray (4607s): "Ты не помнишь, что для всех владельцев iPod это всегда были платные апгрейды?"
+        Одна тема, один стиль аргументации, продолжение мысли.
+        Реплика 4660s: "Критикует он причем не телефоны, а презентацию" - комментарий в
+        контексте диалога Bobuk-Umputun, может быть Gray или Bobuk.
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.75
+          reason: "Та же тема (история iOS на iPod), продолжение собственной мысли"
+        - person_id: "bobuk"
+          confidence: 0.20
+          reason: "Вторая реплика может быть его комментарием"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 4600.1
+          etime: 4606.9
+          text: "Ты просто не помнишь, видимо, как апгрейдилось iOS, по-моему, 2 на iPod Touch."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+      issue: "Ошибочная метка - должен быть Gray (или Bobuk). Эльдар не участвовал в эпизоде."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 357
+    from_speaker: "SPEAKER_01"
+    to_speaker: "NikolayDobrovolskiy"
+    confidence: high
+    reason: "Явное представление в начале эпизода, 238 реплик, вице-президент Parallels"
+
+  - type: rename
+    episode: 357
+    from_speaker: "SPEAKER_00"
+    to_speaker: "AndreyMilinchuk"
+    confidence: high
+    reason: "Явное представление в начале эпизода, 62 реплики, директор по разработке Parallels"
+
+  - type: rename
+    episode: 357
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "Gray"
+    confidence: medium
+    reason: "По контексту - продолжение темы iPod/iOS, которую ведёт Gray. Требует voice verification."
+
+# Новые гости для people.yaml
+new_guests:
+  - id: "nikolay_dobrovolskiy"
+    canonical_name: "NikolayDobrovolskiy"
+    aliases: ["Николай Добровольский", "Николай"]
+    real_name: "Николай Добровольский"
+    info: "Вице-президент Parallels по десктоп-виртуализации, выпуск 357"
+
+  - id: "andrey_milinchuk"
+    canonical_name: "AndreyMilinchuk"
+    aliases: ["Андрей Милинчук", "Милинчук"]
+    real_name: "Андрей Милинчук"
+    info: "Директор по разработке Parallels, выпуск 357"
+
+# Аудио референс для voice comparison
+audio_url: "https://cdn.radio-t.com/rt_podcast357.mp3"

--- a/validation/episodes/0300-0399/0358.yaml
+++ b/validation/episodes/0300-0399/0358.yaml
@@ -1,0 +1,204 @@
+episode: 358
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray, Bobuk]
+  guests_identified: [Marin_k_a, EldarMurtazin]
+  total_duration_sec: 5269  # Umputun 3447 + Gray 1793 + Bobuk 29
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 794
+    replies_count: 188
+    first_appearance_sec: 113
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "viktor_gamov"
+      identification_method: "introduction"
+      confidence: high
+      evidence: >
+        108.3s: Umputun говорит "А наш второй гость Виктор, ты тоже какой-то сибиряк?"
+        SPEAKER_03 отвечает "Нет, это у меня был коллега по другому подкасту, он был сибиряк.
+        Только он был из Иркутска. А я москаль центрального региона. Но сейчас в центральном Нью-Джерси."
+        Виктор - подкастер из Москвы, живёт в Нью-Джерси. Участвует в технических дискуссиях о Stack Overflow, C#.
+        В выпуске 353 был тот же Виктор Гамов из подкаста "Разбор полетов" - вероятно тот же человек.
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 138
+    replies_count: 66
+    first_appearance_sec: 75
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "annie_omsk"
+      identification_method: "introduction"
+      confidence: high
+      evidence: >
+        70.7s: Umputun: "Дорогая Анна, тебя как зовут в интернете?"
+        75.5s: SPEAKER_01: "Нет, у меня в интернетах Энни Омск зовут."
+        Также подтверждено в all_identified_guests.json.
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 299
+    replies_count: 67
+    first_appearance_sec: 1314
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "alexey_spain"
+      identification_method: "introduction"
+      confidence: high
+      evidence: >
+        1314.2s: SPEAKER_00: "Алло."
+        1316.8s: Umputun: "А вот гость, который пришел... Ты говоришь, дорогой... Во-первых, ты кто?"
+        1325.3s: SPEAKER_00: "Алексей."
+        1329.6s: SPEAKER_00: "Я вообще украинец, но в данный момент живу в Испании."
+        Звонящий слушатель, пришёл обсудить ZFS. Также подтверждено в all_identified_guests.json.
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 4
+    replies_count: 4
+    first_appearance_sec: 4602
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Всего 4 короткие реплики разбросаны по эпизоду: "Угу" (4602s), "Да" (5685s),
+        "Угу" (7294s), "Как иначе?" (7405s).
+        Это типичные ошибки автоматического распознавания - междометия и короткие реакции,
+        которые алгоритм не смог атрибутировать корректно.
+        Скорее всего принадлежат одному из ведущих (Gray или Bobuk) или EldarMurtazin.
+      identified_as: null
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.4
+          reason: "Gray активен в этом эпизоде, короткие реакции могут быть его"
+        - person_id: "eldar_murtazin"
+          confidence: 0.3
+          reason: "Эльдар также присутствует, мог бы быть источником"
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 286
+    replies_count: 63
+    first_appearance_sec: 103
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "existing_label"
+      confidence: high
+      evidence: "Уже размечена как Marin_k_a (Марина, бывшая ведущая согласно people.yaml)"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 224
+    replies_count: 50
+    first_appearance_sec: 184
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "eldar_murtazin"
+      identification_method: "existing_label"
+      confidence: high
+      evidence: >
+        Уже размечен как EldarMurtazin (Эльдар Муртазин, ведущий мобильный аналитик согласно people.yaml).
+        Появляется без явного представления в начале - известный регулярный гость.
+      possible_matches: []
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes: >
+    Выпуск 358 от 21 сентября 2013. Состав: Umputun, Gray + два гостя (Анна/Энни Омск и Виктор).
+    Bobuk отсутствует в начале ("вместо выбывшего Бобука"), но появляется с 336s (подключился позже).
+    Marin_k_a (Марина) присутствует как ведущая.
+    EldarMurtazin появляется без представления - известный регулярный гость.
+    SPEAKER_00 (Алексей из Испании) - звонящий слушатель, пришёл в 1314s обсудить ZFS.
+  issues:
+    - speaker: "SPEAKER_01"
+      issue: "Не размечен как AnnieOmsk, хотя явно представилась как Энни Омск"
+    - speaker: "SPEAKER_03"
+      issue: "Не размечен как ViktorGamov, хотя Umputun представил как 'наш гость Виктор'"
+    - speaker: "SPEAKER_00"
+      issue: "Не размечен как AlexeySpain, хотя представился как Алексей из Испании"
+    - speaker: "SPEAKER_05"
+      issue: "Ошибки распознавания - короткие разбросанные реплики"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 358
+    from_speaker: "SPEAKER_03"
+    to_speaker: "ViktorGamov"
+    confidence: high
+    reason: >
+      Явное представление от Umputun: "А наш второй гость Виктор".
+      Виктор - подкастер из Москвы, живёт в Нью-Джерси.
+      Вероятно тот же Виктор Гамов из выпуска 353.
+
+  - type: rename
+    episode: 358
+    from_speaker: "SPEAKER_01"
+    to_speaker: "AnnieOmsk"
+    confidence: high
+    reason: >
+      Явное представление: "Дорогая Анна, тебя как зовут в интернете?" - "Энни Омск".
+      Подтверждено в all_identified_guests.json.
+
+  - type: rename
+    episode: 358
+    from_speaker: "SPEAKER_00"
+    to_speaker: "AlexeySpain"
+    confidence: high
+    reason: >
+      Представился: "Алексей. Я вообще украинец, но в данный момент живу в Испании."
+      Звонящий слушатель с 1314s, обсуждал ZFS.
+
+  - type: delete_or_merge
+    episode: 358
+    speaker: "SPEAKER_05"
+    confidence: medium
+    reason: >
+      4 короткие разбросанные реплики ("Угу", "Да") - ошибки распознавания.
+      Можно удалить или слить с ближайшим по времени спикером.
+
+# Гости для добавления в people.yaml
+new_guests_to_add:
+  - id: "annie_omsk"
+    canonical_name: "AnnieOmsk"
+    aliases: ["Энни", "Энни Омск", "Анна"]
+    real_name: "Анна"
+    info: "Слушательница из Омска, выпуск 358"
+
+  - id: "alexey_spain"
+    canonical_name: "AlexeySpain"
+    aliases: ["Алексей"]
+    real_name: "Алексей"
+    info: "Украинец живущий в Испании, обсуждал ZFS, выпуск 358"
+
+# Примечание: Виктор Гамов уже предложен к добавлению в выпуске 353

--- a/validation/episodes/0300-0399/0359.yaml
+++ b/validation/episodes/0300-0399/0359.yaml
@@ -1,0 +1,296 @@
+episode: 359
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Marin_k_a, SPEAKER_03]
+  total_duration_sec: 7200  # примерно 2 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  # SPEAKER_02 - это Ksenks (Ксюша)
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 348
+    replies_count: 137
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Umputun обращается "Ксюш, можно я скажу..." (311s),
+        после чего SPEAKER_02 отвечает "Конечно, да, надо рассказать..." (318s).
+        Также "Ксюша, ты думаешь, мы про тебя забыли?" (274s),
+        "Откуда у вас там интернет, Ксюша?" (337s).
+        137 реплик, распределённых по эпизоду - типичный паттерн ведущей.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  # SPEAKER_03 - гость, представитель магазина LED-ламп
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 389
+    replies_count: 83
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Появляется с 3340s после слов Gray: "представитель того самого
+        магазина с теплым ламповым светом" (3304s).
+        Umputun спрашивает: "В этом магазине есть кто-то, кроме тебя?" (3337s).
+        SPEAKER_03 отвечает: "Не, ну, вообще-то есть, да. У меня еще сотрудники."
+        Говорит экспертно о LED-лампах, светодиодах, сроке службы, цветопередаче.
+        Имя не названо в эпизоде.
+
+      possible_matches:
+        - person_id: "unknown_led_shop_owner"
+          confidence: 0.9
+          reason: "Владелец/представитель магазина LED-ламп, рекламодатель"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3434.77
+          etime: 3455.4
+          text: "Я вот возьму такой пример, если взять, к примеру, смартфоны на основе Unix ядра, то есть это, допустим, Apple, Android, там Ubuntu сейчас собираются делать, Firefox, то есть у всех ядро и примерно основа одна и та же, но куча нюансов существует."
+
+  # EldarMurtazin - ОШИБКА атрибуции, это смесь Gray и SPEAKER_03
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 187
+    replies_count: 32
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Эльдар Муртазин НЕ присутствует в этом выпуске:
+        1. Его имя НЕ упоминается в тексте (не представляли)
+        2. Реплики на 186-3025s - продолжения речи Gray (о блокноте Evernote,
+           Nexus, SDK). Пример: Gray говорит о своём почерке (171-185s),
+           затем EldarMurtazin: "рукописный почерк у меня" (186s) - это ТОТ ЖЕ человек!
+        3. Реплики на 3838-4025s - это SPEAKER_03 (про LED-лампы).
+           Пример: "параметры светодиодных лампочек" (4025s) идёт перед
+           репликой SPEAKER_03 о цветопередаче.
+        Явная ошибка автоматической атрибуции.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.7
+          reason: "Реплики до 3025s - продолжения речи Gray"
+        - person_id: "SPEAKER_03"
+          confidence: 0.3
+          reason: "Реплики про LED-лампы (3838s, 4025s)"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  # SPEAKER_01 - одиночная короткая реплика
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одиночная реплика (2 сек) в 5742s: "А, то есть это именно компания
+        Parallax сделала..." - скорее всего ошибка распознавания одного из
+        ведущих. Перед ней SPEAKER_02 (Ksenks), после - Gray.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Контекст диалога, Gray отвечает сразу после"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  # SPEAKER_MISATTRIBUTED_PETR - уже помечена как ошибка
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 16
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Префикс SPEAKER_MISATTRIBUTED_ указывает на отменённую ошибочную атрибуцию.
+        Реплика о Knowledge Graph (1246s): "Они говорят, что они используют, там,
+        у них 570 миллионов концептов..." - экспертная речь о технологии Google.
+        Пётр Диденко в выпуске не упоминается.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.6
+          reason: "Gray говорит сразу после этой реплики, контекст совпадает"
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Bobuk говорит сразу перед репликой"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1246.57
+          etime: 1262.48
+          text: "Они говорят, что они используют, там, у них 570 миллионов концептов, ну, то есть, я так понимаю, каких-то семантических форм, которые они будут использовать для того, чтобы..."
+
+  # SPEAKER_MISATTRIBUTED_LAVALE - уже помечена как ошибка
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 4
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Префикс SPEAKER_MISATTRIBUTED_ указывает на отменённую ошибочную атрибуцию.
+        Одиночная короткая реплика (4 сек) в 5858s: "Просто три ключа, то есть
+        они просто безлимитные" - в контексте розыгрыша Parallels.
+        Лаваль в выпуске не упоминается.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.7
+          reason: "Marin_k_a говорит до и после этой реплики о розыгрыше Parallels"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  # Marin_k_a - уже идентифицирована, но проверим
+  - speaker: "Marin_k_a"
+    total_duration_sec: 299
+    replies_count: 46
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "known_participant"
+      confidence: high
+      evidence: |
+        Marin_k_a (Марина) - известная бывшая ведущая подкаста.
+        Первая реплика в 341s: "Я читала, что Google хочет запустить воздушные шары."
+        Активно участвует в обсуждениях на протяжении всего выпуска.
+        46 реплик - типичный паттерн участника.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_02"
+      issue: "Ksenks присутствует, но помечена как SPEAKER_02. Требуется переименование."
+    - speaker: "SPEAKER_03"
+      issue: "Гость (представитель магазина LED-ламп) не назван по имени в эпизоде."
+    - speaker: "EldarMurtazin"
+      issue: "Эльдар Муртазин НЕ присутствует в выпуске. Все реплики - ошибки атрибуции (Gray + SPEAKER_03)."
+    - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+      issue: "Пётр Диденко НЕ присутствует в выпуске. Уже помечено как ошибка."
+    - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+      issue: "Лаваль НЕ присутствует в выпуске. Уже помечено как ошибка."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 359
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Umputun многократно обращается к 'Ксюше' перед репликами SPEAKER_02"
+
+  - type: rename
+    episode: 359
+    from_speaker: "EldarMurtazin"
+    to_speaker: "Gray"
+    time_range: [0, 3300]
+    confidence: medium
+    reason: |
+      Реплики EldarMurtazin до 3300s - продолжения речи Gray.
+      Требует voice comparison для подтверждения.
+
+  - type: rename
+    episode: 359
+    from_speaker: "EldarMurtazin"
+    to_speaker: "SPEAKER_03"
+    time_range: [3300, 10000]
+    confidence: medium
+    reason: |
+      Реплики EldarMurtazin про LED-лампы (3838s, 4025s) - это речь гостя SPEAKER_03.
+      Требует voice comparison для подтверждения.
+
+  - type: rename
+    episode: 359
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Marin_k_a"
+    confidence: medium
+    reason: "Реплика в контексте речи Marin_k_a о розыгрыше Parallels"
+
+  - type: investigate
+    episode: 359
+    speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    reason: "Требуется voice comparison - может быть Gray или Bobuk"
+
+  - type: investigate
+    episode: 359
+    speaker: "SPEAKER_01"
+    reason: "Одиночная реплика, вероятно Gray или ошибка распознавания"
+
+# Примечания
+notes: |
+  Эпизод 359 от 28 сентября 2013 года.
+
+  Основные участники:
+  - Ведущие: Umputun, Bobuk, Gray, Ksenks (помечена как SPEAKER_02)
+  - Гости: Marin_k_a (бывшая ведущая), SPEAKER_03 (представитель магазина LED-ламп)
+
+  Критическая проблема: EldarMurtazin ОШИБОЧНО присутствует в эпизоде.
+  Все 32 его реплики - ошибки автоматической атрибуции:
+  - ~70% - продолжения речи Gray
+  - ~30% - реплики SPEAKER_03 (про лампы)
+
+  Требуется voice comparison для точного разделения реплик EldarMurtazin между Gray и SPEAKER_03.

--- a/validation/episodes/0300-0399/0360.yaml
+++ b/validation/episodes/0300-0399/0360.yaml
@@ -1,0 +1,153 @@
+episode: 360
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [Golodniy]
+  total_duration_sec: 6400  # ~1h 46min
+  notes: |
+    Эпизод от 5 октября 2013 года.
+    Gray и Ksenks отсутствуют (упомянуто в начале).
+    Единственный гость — Голодный (подтверждено в начале и конце эпизода).
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 342
+    replies_count: 103
+    pattern: consecutive
+    first_appearance_sec: 33.4
+
+    analysis:
+      is_error: false
+      identified_as: "golodniy"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        30.46s Umputun: "Голодный."
+        31.26s Umputun: "Почему до сих пор голодный?"
+        33.36s SPEAKER_00: "Да, ну, как бы, тут жена у меня уехала в отпуск, она сейчас в Китае находится, и вот я немножко задержался, я в Иркутске живу..."
+
+        Также в конце эпизода (15805): "Я напомню, что был у нас в гостях голодный..."
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 49
+    replies_count: 4
+    pattern: scattered
+    first_appearance_sec: 1402
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Это реплики, которые ранее были ошибочно приписаны Эльдару Муртазину,
+      # но затем атрибуция была отменена. Судя по контексту, это Голодный.
+      identified_as: "golodniy"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Ключевое доказательство (строка 10810):
+        4454.97s Umputun: "Голодный, ты это восхищен?"
+        4457.47s SPEAKER_MISATTRIBUTED_ELDAR: "Да, красивая история..."
+
+        Umputun обращается к "Голодному", и SPEAKER_MISATTRIBUTED_ELDAR отвечает.
+        Это однозначно указывает, что эти реплики принадлежат Голодному.
+
+        Эльдар Муртазин не участвовал в этом эпизоде (не упоминается в представлении).
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 32
+    replies_count: 5
+    pattern: scattered
+    first_appearance_sec: 193
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Реплики, ранее ошибочно приписанные Петру Диденко.
+      # Судя по контексту и отсутствию Петра в эпизоде, это тоже Голодный.
+      identified_as: "golodniy"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Петр Диденко не упоминается в этом эпизоде (не представлен).
+        В финале эпизода подтверждается единственный гость — Голодный.
+
+        Примеры реплик SPEAKER_MISATTRIBUTED_PETR:
+        192.57s: "Мне кажется, любое направление можно превратить в карго-культ..."
+        3444.11s: "Учитывая весь этот геморрой и то количество серверов..."
+
+        Контекст соответствует техническому обсуждению, в котором участвует гость (Голодный).
+        Однако без voice comparison нельзя быть на 100% уверенным.
+
+      possible_matches:
+        - person_id: "golodniy"
+          confidence: 0.75
+          reason: "Единственный гость в эпизоде, технический контекст соответствует"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3444.11
+          etime: 3452.20
+          text: "Учитывая весь этот геморрой и то количество серверов, которые ты сказал, как у тебя вообще с коллабилити в трех зонах?"
+        compare_with:
+          speaker: "SPEAKER_00"
+          stime: 33.36
+          etime: 50.43
+          text: "Да, ну, как бы, тут жена у меня уехала в отпуск, она сейчас в Китае находится..."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes: |
+    Голодный явно представлен в начале эпизода (30.46s).
+    В конце эпизода подтверждается состав: "был у нас в гостях голодный, был у нас не в гостях, а дома Бобук"
+  issues:
+    - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+      issue: "Требуется voice comparison для подтверждения, что это Голодный"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 360
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Golodniy"
+    confidence: high
+    reason: "Явное представление в начале эпизода и подтверждение в конце"
+
+  - type: rename
+    episode: 360
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "Golodniy"
+    confidence: high
+    reason: "Umputun обращается к Голодному, SPEAKER_MISATTRIBUTED_ELDAR отвечает (4454-4457s)"
+
+  - type: rename
+    episode: 360
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    to_speaker: "Golodniy"
+    confidence: medium
+    reason: "Единственный гость в эпизоде; требуется voice comparison для подтверждения"
+
+# Дополнительные заметки
+notes: |
+  Эпизод 360 имеет чистую структуру с одним гостем.
+
+  SPEAKER_MISATTRIBUTED_* — это маркеры отменённых ошибочных атрибуций.
+  Ранее эти реплики были приписаны Эльдару Муртазину и Петру Диденко,
+  но затем атрибуция была отменена, так как ни один из них не участвовал в этом эпизоде.
+
+  После voice comparison все три спикера (SPEAKER_00, SPEAKER_MISATTRIBUTED_ELDAR,
+  SPEAKER_MISATTRIBUTED_PETR) должны быть объединены под именем Golodniy.

--- a/validation/episodes/0300-0399/0361.yaml
+++ b/validation/episodes/0300-0399/0361.yaml
@@ -1,0 +1,272 @@
+episode: 361
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Контекст выпуска
+episode_context: |
+  Дата: 12 октября 2013
+  Umputun в начале говорит: "парный выпуск", "мы с Ксюшей вдвоем"
+  Бобук и Грей отсутствуют ("в пути")
+  В конце подтверждено: "Сегодня мы с Ксюшей вдвоем выступили, но с поддержкой дорогих гостей"
+
+  Гости:
+  - Антон (подключился около 443 сек, ушел около 2267 сек)
+  - Андрей (владелец музея Apple в Москве, с ~2577 сек до конца)
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Ksenks]
+  hosts_absent: [Bobuk, Gray]
+  total_duration_sec: 7200  # ~2 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 1332
+    replies_count: 410
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Umputun обращается к спикеру как "Ксюша", "Ксюшенька" многократно.
+        В начале выпуска: "Ксюша, хорошо, что ты пришла" (34 сек).
+        SPEAKER_00 реагирует: "Да, я сегодня отдаваюсь изо всех отсутствующих" (36 сек).
+        В конце: "Сегодня мы с Ксюшей вдвоем выступили".
+        Марина не упоминается ни разу.
+
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 621
+    replies_count: 105
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Ошибочная атрибуция. Марина не участвовала в выпуске 361.
+        Umputun явно говорит "парный выпуск" с Ксюшей, а не с Мариной.
+        Марина (Marin_k_a) не упоминается ни разу в течение всего эпизода.
+        Все обращения только к "Ксюша/Ксюшенька".
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: "Марина не упоминается, только Ксюша. Реплики Marin_k_a следуют за репликами к 'Ксюше'."
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 1128
+    replies_count: 277
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: null  # Требуется добавление в people.yaml
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Umputun вызывает: "Андрей." (2576 сек) — SPEAKER_02: "Да, я здесь."
+        SPEAKER_02 представляется: "Есть музей техники Apple в Москве. Я являюсь его создателем, учредителем" (2693-2701 сек).
+        К нему приезжал Стив Возняк в музей.
+        В конце: "Андрей, спасибо, что зашел к нам в выпуск" (5685 сек).
+
+      possible_matches:
+        - person_id: "andrey_antonov"  # Нужно добавить в people.yaml
+          confidence: 0.9
+          reason: "Андрей, владелец музея Apple в Москве (museum.apple.ru или подобный)"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2883.88
+          etime: 2896.9
+          text: "97-98 год. Джобс возвращается в контору, закрывает все, что им не нравится, распродает все, что можно еще продать."
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 131
+    replies_count: 35
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: null  # Гость Антон, требуется идентификация
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        SPEAKER_00: "О, к нам подключился какой-то гость" (433 сек).
+        Umputun: "Кстати, гость, ты кто? Привет, я Антон." (442-443 сек).
+        Umputun: "Антон, спасибо, что пришел к нам" (2266 сек).
+        SPEAKER_01 активен с 459 до ~2260 сек.
+
+      possible_matches:
+        - person_id: "anton_guest_361"
+          confidence: 0.7
+          reason: "Гость Антон, обсуждал peer-to-peer технологии"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 464.63
+          etime: 470.15
+          text: "Причем есть даже подозрение, что можно будет всю историю свою всю жизнь наблюдать."
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 60
+    replies_count: 10
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      identified_as: "eldar_murtazin"
+      identification_method: "existing_attribution"
+      confidence: high
+      evidence: "Уже размечен корректно. Известный мобильный аналитик."
+
+      voice_task:
+        needed: false
+
+  - speaker: "Gray"
+    total_duration_sec: 5
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Gray был "в пути" весь выпуск по словам Umputun.
+        Единственная реплика (3143 сек): "Жень, я думаю, все это все-таки в голове, потому что телефон, в общем, для того, чтобы звонить."
+        Скорее всего это кто-то из гостей (Андрей или другой), ошибочно приписанный Gray.
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3143.66
+          etime: 3148.68
+          text: "Жень, я думаю, все это все-таки в голове, потому что телефон, в общем, для того, чтобы звонить."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 31
+    replies_count: 8
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Отменённое ошибочное присвоение. Lavale не участвовала в этом выпуске."
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 202.47
+          etime: 205.91
+          text: "Ну, то есть, еще без продукта написать. А ты думаешь, они уже альфа?"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 8
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Отменённое ошибочное присвоение. Пётр Диденко не участвовал в этом выпуске."
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1494.85
+          etime: 1497.83
+          text: "Или это кусок картинки."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Marin_k_a"
+      issue: "Марина размечена как спикер, но не упоминается ни разу. Это Ksenks."
+
+    - speaker: "SPEAKER_00"
+      issue: "Это Ksenks, требуется переименование."
+
+    - speaker: "Gray"
+      issue: "Gray отсутствовал ('в пути'), но имеет 1 реплику. Скорее всего ошибка."
+
+    - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+      issue: "Отменённые атрибуции Lavale. Скорее всего это Ksenks."
+
+    - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+      issue: "Отменённые атрибуции Petr. Скорее всего это Ksenks или гость."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 361
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Umputun многократно обращается 'Ксюша', 'Ксюшенька'. Марина не упоминается."
+
+  - type: rename
+    episode: 361
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Ошибочная атрибуция. Umputun говорит 'парный выпуск с Ксюшей', Марина не упоминается ни разу."
+
+  - type: rename
+    episode: 361
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Anton_Guest"
+    confidence: high
+    reason: "Гость представился 'Привет, я Антон'. Прощание: 'Антон, спасибо, что пришел к нам'."
+
+  - type: rename
+    episode: 361
+    from_speaker: "SPEAKER_02"
+    to_speaker: "AndreyAppleMuseum"
+    confidence: high
+    reason: "Андрей, владелец музея Apple в Москве. Явное представление: 'Есть музей техники Apple в Москве. Я являюсь его создателем'."
+
+  - type: rename
+    episode: 361
+    from_speaker: "Gray"
+    to_speaker: "SPEAKER_UNKNOWN"
+    confidence: medium
+    reason: "Gray был 'в пути'. Единственная реплика скорее принадлежит гостю. Требуется voice comparison."
+
+  - type: rename
+    episode: 361
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: "Lavale не участвовала. Короткие реплики похожи на Ksenks по контексту. Требуется voice comparison."
+
+  - type: rename
+    episode: 361
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: "Пётр Диденко не участвовал. Требуется voice comparison."
+
+# Задачи для ручной проверки
+manual_review_tasks:
+  - task: "voice_comparison"
+    description: "Сравнить голос Gray (3143-3148 сек) с голосами SPEAKER_02 и Ksenks"
+    priority: medium
+
+  - task: "add_to_people_yaml"
+    description: |
+      Добавить гостей в people.yaml:
+      - Андрей (владелец музея Apple в Москве)
+      - Антон (гость выпуска 361)
+    priority: high
+
+  - task: "verify_ksenks_attribution"
+    description: "Подтвердить что SPEAKER_00, Marin_k_a, SPEAKER_MISATTRIBUTED_* — это Ksenks"
+    priority: high

--- a/validation/episodes/0300-0399/0362.yaml
+++ b/validation/episodes/0300-0399/0362.yaml
@@ -1,0 +1,133 @@
+episode: 362
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_announced: false  # "унылый мужской состав", "три гада" - гостей нет
+  total_duration_sec: 6409.2  # Bobuk 2807 + Umputun 2787 + Gray 788 + misc
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 1.3
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткая реплика (1.3с) между двумя репликами Umputun. Текст 'Типа вас с вами' - продолжение шутки про open source разработчиков. Ошибка сегментации речи."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.6
+          reason: "Bobuk активно участвует в диалоге, может перебить шуткой"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Gray тоже присутствует, но менее активен в этот момент"
+
+      voice_task:
+        needed: false
+        reason: "Слишком короткая реплика (1.3с) для voice comparison"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 24.3
+    replies_count: 7
+    pattern: scattered  # Реплики разбросаны по всему эпизоду
+
+    analysis:
+      is_error: true
+      error_reason: "Эльдар Муртазин НЕ участвовал в этом эпизоде (представлены только Umputun, Bobuk, Gray). MISATTRIBUTED указывает на отменённую ошибочную атрибуцию. Все реплики принадлежат одному из ведущих."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "В начале выпуска Umputun говорит 'сегодня у нас унылый мужской состав, исключительно три гада'. Никакие гости не представлены."
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.7
+          reason: "Большинство реплик находятся между репликами Gray или продолжают его мысль (558s, 5032s, 6614s). Контекст про RedHat, Кинопоиск - темы которые обсуждает Gray."
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Некоторые реплики между репликами Bobuk (4762s, 2212s через PETR)"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6663.7
+          etime: 6670.9
+          text: "На самом деле-то мы же понимаем, что на чем у них написано, неважно."
+          note: "Самая длинная реплика (7.2с), чистая речь"
+        compare_with:
+          - speaker: "Gray"
+            reason: "Наиболее вероятный спикер по контексту"
+          - speaker: "Bobuk"
+            reason: "Альтернативный вариант"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 2.2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Пётр Диденко НЕ участвовал в этом эпизоде. Реплика между двумя репликами Bobuk, текст 'Ну, половина пулеметов вниз' - продолжение шутки про дата-центры. MISATTRIBUTED указывает на отменённую ошибку."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.6
+          reason: "Umputun ранее сказал 'И пулеметы так вниз' (2207s), эта реплика продолжает его шутку"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Gray тоже присутствует"
+
+      voice_task:
+        needed: false
+        reason: "Слишком короткая реплика (2.2с) для надёжного voice comparison"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes: "Все три ведущих упомянуты в начале. Гостей не было."
+  issues:
+    - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+      issue: "7 реплик ошибочно размечены. Эльдар не участвовал, нужно переатрибутировать к Gray или Bobuk."
+    - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+      issue: "1 реплика ошибочно размечена. Пётр не участвовал, нужно переатрибутировать к Umputun или Gray."
+    - speaker: "SPEAKER_04"
+      issue: "1 короткая реплика - ошибка сегментации, нужно объединить с соседней или переатрибутировать."
+
+# Предлагаемые правила очистки
+# ВНИМАНИЕ: требуется voice comparison для точной атрибуции SPEAKER_MISATTRIBUTED_ELDAR
+suggested_rules: []
+# Не предлагаю конкретные правила без voice comparison, так как:
+# - Невозможно точно определить спикера по тексту
+# - MISATTRIBUTED реплики могут принадлежать разным ведущим
+# - Требуется прослушивание для корректной атрибуции
+
+# Рекомендации
+recommendations:
+  - action: "voice_comparison"
+    priority: high
+    description: "Прослушать сегмент 6663-6671s и сравнить с голосами Gray и Bobuk"
+  - action: "manual_review"
+    priority: medium
+    description: "Проверить все SPEAKER_MISATTRIBUTED реплики на слух и переатрибутировать"
+  - action: "merge_or_delete"
+    priority: low
+    description: "SPEAKER_04 (391s) - объединить с соседней репликой или удалить как ошибку сегментации"
+
+# Аудио для проверки
+audio_url: null  # Файл метаданных недоступен в data_clean

--- a/validation/episodes/0300-0399/0363.yaml
+++ b/validation/episodes/0300-0399/0363.yaml
@@ -1,0 +1,235 @@
+episode: 363
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray, Ksenks]
+  guests_present: [Plushev]
+  total_duration_sec: 6124  # примерно из статистики
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 2082
+    replies_count: 550
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "plushev"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "Umputun в 37-40s: 'Это я про Плющева Александра. Небезызвестного.' Сразу после этого SPEAKER_03 (40s): 'Добрый вечер. Да, я все видел. Я был в городе Лондоне.'"
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 235
+    replies_count: 88
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "Bobuk спрашивает 'Ксюш, ты откуда сегодня вообще?' (710s), SPEAKER_04 отвечает 'Я с выезда, я тут не на врага территории, в Бесчере' (715s). Также Umputun говорит 'Ксюшенька' перед репликами SPEAKER_04."
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 216
+    replies_count: 39
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: "Umputun говорит 'Ворвалась стремительным домкратом, Ксюша' (671s), сразу после Marin_k_a: 'Да, я не могла не сказать...' (674s). Marin_k_a и SPEAKER_04 чередуются, отвечая на обращения к Ксюше."
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 54
+    replies_count: 9
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибочная атрибуция - реплики продолжают мысли SPEAKER_03 (Плющева) и идут с ним подряд. Например, на 3918s SPEAKER_03 говорит про маленькие планшеты, затем SPEAKER_MISATTRIBUTED_ELDAR продолжает ту же мысль 'И, в общем, как-то все поняли, что он ничем не хуже...', а потом снова SPEAKER_03 отвечает 'Он и стал огонь'."
+
+      identified_as: "plushev"
+      identification_method: "context"
+      confidence: medium
+      evidence: "Реплики являются продолжением мыслей SPEAKER_03. Нет признаков присутствия Эльдара Муртазина в эпизоде."
+
+      possible_matches:
+        - person_id: "plushev"
+          confidence: 0.8
+          reason: "Реплики последовательно чередуются с SPEAKER_03 и продолжают те же темы"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 306.3
+          etime: 316.3
+          text: "Ну, ты знаешь, такие вещи, я тебе скажу, ты наверняка знаешь это или подозревал, или, по меньшей мере, на подсознательном уровне понимаешь, что некоторые вещи пишутся заранее."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 13
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибочная атрибуция - реплики идут подряд с Marin_k_a и SPEAKER_04, которые оба являются Ксюшей. Тематика та же (ретина, батарея, проблемы первых версий)."
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: "На 1721s SPEAKER_MISATTRIBUTED_LAVALE говорит между SPEAKER_04 (1715s) и Marin_k_a (1730s) на ту же тему про проблемы с ретиной."
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.75
+          reason: "Реплики чередуются с Marin_k_a и SPEAKER_04, которые идентифицированы как Ksenks"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1721.2
+          etime: 1730.1
+          text: "Когда выходит какое-то новое устройство, первая пилотная, первая версия, всегда есть какие-то проблемы с ретиной. Очень было у многих битые пиксели."
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 1
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие реплики (1 сек суммарно) - 'Она самая любимая' и 'А?'. Скорее всего ошибка распознавания или перебивка одного из ведущих."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Реплика следует за Bobuk (1156-1160s), может быть его перебивка"
+        - person_id: "umputun"
+          confidence: 0.4
+          reason: "Umputun отвечает сразу после (1164s) фразой 'Самая любимая диками фича', подхватывая тему"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Gray"
+    total_duration_sec: 4
+    replies_count: 1
+    pattern: single
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Gray - известный ведущий, но только 1 реплика подозрительно мало
+      identified_as: "gray"
+      identification_method: "attribution"
+      confidence: medium
+      evidence: "Единственная реплика Gray на 4178s: 'Вот, и ты просто листаешь, и все.' в контексте разговора о iPad в магазинах."
+
+      possible_matches: []
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 4178.2
+          etime: 4181.8
+          text: "Вот, и ты просто листаешь, и все."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Gray"
+      issue: "Только 1 реплика (4 сек) за весь эпизод. Umputun в начале говорит 'в мужском составе', но не называет конкретных участников. Возможно Gray действительно был мало, или это ошибка атрибуции."
+    - speaker: "Ksenks"
+      issue: "Не представлена в начале (Umputun говорит 'мужской состав'), но появляется на 670s. Umputun замечает 'Ворвалась стремительным домкратом, Ксюша' - т.е. она подключилась позже."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 363
+    from_speaker: "SPEAKER_03"
+    to_speaker: "Plushev"
+    confidence: high
+    reason: "Явное представление: 'Это я про Плющева Александра' перед первой репликой SPEAKER_03"
+
+  - type: rename
+    episode: 363
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Прямые обращения к Ксюше перед и после реплик SPEAKER_04"
+
+  - type: rename
+    episode: 363
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Чередуется с SPEAKER_04, оба отвечают на обращения к Ксюше"
+
+  - type: rename
+    episode: 363
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "Plushev"
+    confidence: medium
+    reason: "Реплики продолжают мысли SPEAKER_03 (Плющева), нет признаков присутствия Муртазина"
+
+  - type: rename
+    episode: 363
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: "Реплики чередуются с Marin_k_a/SPEAKER_04 на ту же тему"
+
+  - type: delete
+    episode: 363
+    from_speaker: "SPEAKER_00"
+    confidence: medium
+    reason: "Короткие артефакты (1 сек), не отдельный спикер"
+
+# Дополнительные заметки
+notes:
+  - "Эпизод от 26.10.2013, обсуждение презентации Apple (iPad mini с ретиной, Maverick)"
+  - "Плющев был 'корреспондентом' из Лондона"
+  - "Ксюша подключилась позже начала, Umputun отметил это ('Ворвалась стремительным домкратом')"
+  - "У Ксюши были проблемы с интернетом ('ты прерываешься', 'очень плохо')"
+  - "Gray почти не говорил - это требует отдельной проверки"
+
+audio_url: "https://cdn.radio-t.com/rt_podcast363.mp3"

--- a/validation/episodes/0300-0399/0364.yaml
+++ b/validation/episodes/0300-0399/0364.yaml
@@ -1,0 +1,200 @@
+episode: 364
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [SPEAKER_01, SPEAKER_03, EldarMurtazin]
+  total_duration_sec: 8170  # ~2h 16m based on speaker stats
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 918
+    replies_count: 251
+    first_appearance_sec: 87
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "VictorGamov"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        На 95.78s SPEAKER_01 говорит: "Ну да, если вы слышите эти дурацкие шуточки,
+        значит, вы слышите голоса Алексея Абашева и Виктора Гамова."
+        На 3339.22s SPEAKER_01 обращается к Лёше: "Ну, ты просто-напросто, Леша,
+        пытается сказать..." - значит SPEAKER_01 это НЕ Лёша, а Виктор Гамов.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment:
+          stime: 95.78
+          etime: 103.18
+          text: "Ну да, если вы слышите эти дурацкие шуточки, значит, вы слышите голоса Алексея Абашева и Виктора Гамова."
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 978
+    replies_count: 182
+    first_appearance_sec: 241
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "AlexeyAbashev"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        На 3339.22s SPEAKER_01 обращается к "Леша" - это SPEAKER_03.
+        В начале выпуска представлены "Алексей Абашев и Виктор Гамов".
+        SPEAKER_03 активно обсуждает технические темы (Java, C++, websockets).
+        На 3345.88s отвечает на обращение "Леша".
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment:
+          stime: 244.08
+          etime: 256.39
+          text: "Я думаю, он готов и очень с альтернативным сознанием, и у него все это как живое. Все эти кони, трубы и андроиды, которые как-то дают свободу или как-то... С искусственным интеллектом."
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 264
+    replies_count: 42
+    first_appearance_sec: 137
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Ошибочная атрибуция. В эпизоде 364 участвуют Виктор Гамов и Алексей Абашев,
+        НЕ Эльдар Муртазин. Реплики "EldarMurtazin" содержат техническое обсуждение
+        (C++, websockets, MongoDB, SSH, Docker), что не соответствует профилю
+        Эльдара Муртазина (мобильный аналитик). Вероятно, это реплики одного из
+        гостей (Виктор или Алексей), ошибочно атрибутированные.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "VictorGamov"
+          confidence: 0.5
+          reason: "Техническое содержание реплик совпадает с тематикой выпуска"
+        - person_id: "AlexeyAbashev"
+          confidence: 0.5
+          reason: "Техническое содержание реплик совпадает с тематикой выпуска"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3463.66
+          etime: 3481.26
+          text: "Длинная техническая реплика для сравнения голоса"
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 1
+    replies_count: 1
+    first_appearance_sec: 1409
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная короткая реплика "Как?" (0.68 сек) - типичная ошибка
+        автоматического распознавания. Скорее всего принадлежит одному из
+        присутствующих спикеров (вероятно Bobuk или один из гостей).
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Короткая переспрашивающая реплика в стиле Бобука"
+        - person_id: "VictorGamov"
+          confidence: 0.3
+          reason: "Гость присутствовал в этот момент"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes: |
+    - Umputun и Bobuk ведут с начала
+    - Gray присоединяется позже (с 1657s), без формального представления - это нормально для ведущего
+    - Гости Виктор Гамов и Алексей Абашев представлены на 95.78s
+  issues:
+    - speaker: "EldarMurtazin"
+      issue: |
+        42 реплики ошибочно атрибутированы как EldarMurtazin.
+        Эльдар Муртазин НЕ участвовал в этом выпуске.
+        Требуется voice comparison для определения, кому принадлежат эти реплики.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 364
+    from_speaker: "SPEAKER_01"
+    to_speaker: "VictorGamov"
+    confidence: high
+    reason: |
+      Идентифицирован через представление на 95.78s и обращение к "Леша" на 3339s.
+
+  - type: rename
+    episode: 364
+    from_speaker: "SPEAKER_03"
+    to_speaker: "AlexeyAbashev"
+    confidence: high
+    reason: |
+      Идентифицирован как "Леша" через обращение SPEAKER_01 на 3339s.
+      Представлен в начале как "Алексей Абашев".
+
+  - type: review_required
+    episode: 364
+    from_speaker: "EldarMurtazin"
+    to_speaker: null
+    confidence: null
+    reason: |
+      Ошибочная атрибуция. Требуется voice comparison для определения,
+      это Виктор Гамов или Алексей Абашев.
+
+  - type: review_required
+    episode: 364
+    from_speaker: "SPEAKER_04"
+    to_speaker: null
+    confidence: null
+    reason: |
+      Единственная реплика "Как?" - вероятно ошибка распознавания.
+      Можно удалить или переатрибутировать после voice comparison.
+
+# Новые гости для people.yaml
+new_guests_for_registry:
+  - id: "victor_gamov"
+    canonical_name: "VictorGamov"
+    aliases: ["Витя", "Gamov"]
+    real_name: "Виктор Гамов"
+    info: "Автор книги по Java/Enterprise, выпуск 364"
+
+  - id: "alexey_abashev"
+    canonical_name: "AlexeyAbashev"
+    aliases: ["Леша", "Abashev", "Алексей"]
+    real_name: "Алексей Абашев"
+    info: "Автор книги по Java/Enterprise, выпуск 364"
+
+# Аудио для voice comparison
+audio_url: null  # Требуется получить из 364_desc.json в data/

--- a/validation/episodes/0300-0399/0365.yaml
+++ b/validation/episodes/0300-0399/0365.yaml
@@ -1,0 +1,222 @@
+episode: 365
+status: has_tasks
+analyzed_at: "2026-01-25"
+
+# Эпизод от 9 ноября 2013 года (выпуск 365)
+
+speakers_summary:
+  hosts_present: [Umputun, Gray, Bobuk]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 6563
+  notes: |
+    Основные ведущие: Umputun (3292 сек), Gray (1639 сек), Bobuk (31 сек).
+    Гость: Marin_k_a (Марина, бывшая ведущая) - 915 сек.
+    SPEAKER_01 это явно Ksenks (551 сек) - требуется переименование.
+
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 551
+    replies_count: 252
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        На 27.9s Umputun спрашивает: "Ксюшенька, мы поможем сегодня себе сами? Или тебя называть сегодня Оксана..."
+        На 31.9s SPEAKER_01 отвечает: "Нет, меня Ксюшенька называть."
+        Это прямое подтверждение, что SPEAKER_01 = Ksenks.
+        Дополнительно: женские реплики ("Ну я же сама", "Я его потрогала") соответствуют Ксении.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 9
+    replies_count: 5
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие разрозненные реплики (2-3 сек каждая), всего 5 штук за весь эпизод.
+        Скорее всего ошибки распознавания одного из ведущих или Marin_k_a.
+        Примеры: "Да, Женя так удивился" (93.9s), "Понятно" (5402s).
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Реплики похожи на женские комментарии"
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "Может быть ошибочно разделённая речь Марины"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+        reason: "Слишком короткие сегменты (<3 сек) для надёжного voice comparison"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 52
+    replies_count: 11
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Это не Эльдар - реплики были ошибочно атрибутированы, а потом отменены
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        SPEAKER_MISATTRIBUTED_ELDAR означает, что ранее эти реплики были ошибочно приписаны
+        Эльдару Муртазину, но потом атрибуция была отменена.
+        По контексту: аналитические комментарии, скорее всего мужской голос.
+        Нужно определить реального спикера.
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: |
+            Многие реплики окружены репликами Gray'я, стиль похож на аналитические
+            комментарии Gray'я. Возможно, ошибка распознавания его голоса.
+        - person_id: "bobuk"
+          confidence: 0.2
+          reason: |
+            Маловероятно - у Bobuk в этом эпизоде мало реплик (9), а MISATTRIBUTED
+            реплики распределены по всему эпизоду в местах, где Bobuk не говорит.
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 4934.4
+          etime: 4944.6
+          text: "Но при этом все остальное, там, в общем, ничего близко нету к iMac, потому что i5, я подозреваю, не самый мощный."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 38
+    replies_count: 7
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        SPEAKER_MISATTRIBUTED_LAVALE означает отменённую ошибочную атрибуцию к Лаваль.
+        Реплики распределены по эпизоду, характер неопределённый.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: |
+            Несколько реплик расположены рядом с репликами SPEAKER_01 (=Ksenks).
+            Возможно, это её реплики, ошибочно отнесённые к другому спикеру.
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: |
+            Также могут быть репликами Марины, которые были неверно атрибутированы.
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 551.7
+          etime: 561.8
+          text: "Но я так понимаю, что может быть похожая ситуация, как бывало, например, с айфонами, когда Apple выкатывает какое-то лимитированное количество устройств на все страны."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика длиной 2.5 сек: "Видимо, грядут часы" (3708.5s).
+        Слишком мало данных для идентификации, скорее всего ошибка распознавания.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Контекст обсуждения часов, типичная тема для Gray'я"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Может быть ошибочно отнесённая реплика Ксении"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+        reason: "Слишком короткий сегмент (2.5 сек) для voice comparison"
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 915
+    replies_count: 174
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Marin_k_a уже идентифицирована в people.yaml как Марина (бывшая ведущая).
+        Говорит много (915 сек), активно участвует в обсуждениях.
+        Обращается к ведущим по имени ("Женя, это же ты любишь", "Грей, если у тебя день рождения").
+
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "SPEAKER_01"
+      issue: "Явно Ksenks, но не переименован в транскрипте"
+    - speaker: "SPEAKER_MISATTRIBUTED_*"
+      issue: "Три MISATTRIBUTED спикера требуют реатрибуции после отмены предыдущих ошибочных атрибуций"
+
+suggested_rules:
+  - type: rename
+    episode: 365
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Прямое подтверждение в диалоге: Umputun спрашивает "Ксюшенька...или тебя называть Оксана",
+      SPEAKER_01 отвечает "Нет, меня Ксюшенька называть".
+      252 реплики, 551 секунд - значительное присутствие в эпизоде.
+
+notes: |
+  Эпизод 365 содержит полный состав ведущих (Umputun, Gray, Bobuk) плюс гостью Марину (Marin_k_a).
+
+  SPEAKER_01 = Ksenks с высокой уверенностью - требуется переименование.
+
+  SPEAKER_MISATTRIBUTED_* спикеры - это отменённые ошибочные атрибуции к известным гостям
+  (Эльдар, Лаваль, Пётр), которые теперь требуют повторной идентификации.
+  Судя по контексту, это скорее реплики одного из ведущих (вероятно Gray или ошибки
+  распознавания женских голосов).
+
+  SPEAKER_02 - скорее всего ошибки распознавания, слишком мало данных.

--- a/validation/episodes/0300-0399/0366.yaml
+++ b/validation/episodes/0300-0399/0366.yaml
@@ -1,0 +1,202 @@
+episode: 366
+status: has_tasks
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7200  # ~2 часа (примерная оценка)
+
+  # Подробная статистика (из предрассчитанных данных)
+  speaker_stats:
+    - speaker: Umputun
+      replies: 1206
+      duration_sec: 3397
+      first_at: 4
+    - speaker: Bobuk
+      replies: 752
+      duration_sec: 2355
+      first_at: 21
+    - speaker: Marin_k_a
+      replies: 167
+      duration_sec: 870
+      first_at: 84
+    - speaker: SPEAKER_00
+      replies: 236
+      duration_sec: 439
+      first_at: 23
+    - speaker: SPEAKER_MISATTRIBUTED_LAVALE
+      replies: 10
+      duration_sec: 36
+      first_at: 179
+    - speaker: SPEAKER_03
+      replies: 3
+      duration_sec: 2
+      first_at: 1601
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: SPEAKER_00
+    total_duration_sec: 439
+    replies_count: 236
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: ksenks
+      identification_method: introduction
+      confidence: high
+      evidence: |
+        1. Umputun представляет в начале: "У нас есть Ксюша, у нас есть Бобук" (13.5s)
+        2. SPEAKER_00 говорит "я была" в женском роде (29.4s)
+        3. Прямое обращение Umputun: "А ты, Ксюша?" (194.3s), после чего SPEAKER_00 отвечает (196.6s)
+        4. Bobuk: "Ксюша, давай, включайся" (199.2s), SPEAKER_00 отвечает (200.7s)
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: Marin_k_a
+    total_duration_sec: 870
+    replies_count: 167
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Уже идентифицирована в people.yaml
+      identified_as: marin_k_a
+      identification_method: context
+      confidence: high
+      evidence: |
+        Marin_k_a уже идентифицирована в people.yaml как Марина (бывшая ведущая).
+        Подтверждается женским родом в репликах:
+        - "я тогда думала" (4612.5s)
+        - "я согласна" (6035.9s)
+        Активное участие (167 реплик, 870 сек) подтверждает статус участника.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: SPEAKER_MISATTRIBUTED_LAVALE
+    total_duration_sec: 36
+    replies_count: 10
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Спикер помечен как MISATTRIBUTED — это ошибочная атрибуция, которая была отменена.
+        Анализ контекста показывает, что реплики относятся к Ksenks (SPEAKER_00):
+        - 178.9s: продолжение разговора SPEAKER_00 о цифровых темах
+        - Женский голос, согласуется с Ksenks
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: ksenks
+          confidence: 0.8
+          reason: Контекст указывает на продолжение реплик Ksenks
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3147.64
+          etime: 3169.25
+          text: |
+            "Зато во всех магазинах и во всех каких-то точках понатыкано уже вот этих автоматов."
+            "То есть везде все больше и больше появляется возможность платить картой."
+            "Это такая карта, которая агрегирует кучу карт."
+          note: "Самый длинный непрерывный сегмент (~22 сек)"
+
+  - speaker: SPEAKER_03
+    total_duration_sec: 2
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Всего 3 очень короткие реплики (<2 сек каждая) в разных частях эпизода:
+        - 1600.6s: "Не?" (0.9 сек)
+        - 2519.1s: "Ребята честные, да?" (1.8 сек)
+        - 6561.5s: "Может, ты чистую поставил?" (аномальный etime < stime)
+        Типичные фразы-ошибки распознавания, вероятно принадлежат одному из ведущих.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: ksenks
+          confidence: 0.5
+          reason: Короткие реплики в диалоге, могут быть ошибочно отсечены от SPEAKER_00
+        - person_id: bobuk
+          confidence: 0.3
+          reason: Контекст некоторых реплик около высказываний Bobuk
+
+      voice_task:
+        needed: false
+        reference_segment: null
+        note: "Слишком короткие сегменты для voice comparison"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: Marin_k_a
+      issue: |
+        Марина не представлена в начале эпизода. Umputun говорит только
+        "У нас есть Ксюша, у нас есть Бобук" (13.5s), но Марина появляется
+        с первой репликой уже на 83.6s, активно участвуя в разговоре.
+        Возможно представление было неполным или она известна слушателям как постоянная участница.
+    - speaker: SPEAKER_00
+      issue: |
+        SPEAKER_00 (Ksenks) не был автоматически переименован, хотя идентификация очевидна.
+        236 реплик должны быть переименованы в Ksenks.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 366
+    from_speaker: SPEAKER_00
+    to_speaker: Ksenks
+    confidence: high
+    reason: |
+      Прямая идентификация через представление и обращения:
+      - "У нас есть Ксюша" (13.5s)
+      - "А ты, Ксюша?" -> SPEAKER_00 отвечает (194-196s)
+      - "Ксюша, давай, включайся" -> SPEAKER_00 отвечает (199-200s)
+
+  - type: rename
+    episode: 366
+    from_speaker: SPEAKER_MISATTRIBUTED_LAVALE
+    to_speaker: Ksenks
+    confidence: medium
+    reason: |
+      Контекст указывает на продолжение реплик Ksenks.
+      Требует подтверждения через voice comparison.
+
+  - type: delete_or_merge
+    episode: 366
+    from_speaker: SPEAKER_03
+    to_speaker: null
+    confidence: medium
+    reason: |
+      Ошибки распознавания: 3 очень короткие реплики (<2 сек).
+      Одна реплика имеет аномальный timestamp (etime < stime).
+      Требует ручной проверки для определения реального автора.

--- a/validation/episodes/0300-0399/0367.yaml
+++ b/validation/episodes/0300-0399/0367.yaml
@@ -1,0 +1,215 @@
+episode: 367
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 5353  # ~89 минут
+
+# Примечание: в начале выпуска Umputun говорит "нас трое"
+# Ведущие: Umputun, Gray, Marin_k_a (Марина была ведущей в выпусках 106-538)
+# Bobuk присутствует минимально (8 реплик) - возможно подключился кратко
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1243
+    replies_count: 335
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Marin_k_a (Марина) была ведущей в выпусках 106-538 (согласно participants.md).
+        Эпизод 367 входит в этот диапазон. Umputun обращается к ней "Ксюша" -
+        возможно прозвище или шутливое обращение. Ksenks начала вести только с 409 выпуска.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 42
+    replies_count: 9
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Это не Эльдар Муртазин - метка говорит что присвоение было ошибочным и отменено
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Реплики разбросаны по всему выпуску. Содержание технических комментариев:
+        - "Это означает, что какие-то части доступны без HTTPS" (3330s)
+        - "Нет, нет, нет, это не по Google Voice совершенно" (4699s) - Umputun отвечает "у вас там свой Яндекс.Войс"
+        - "LG, насколько я понимаю, пообещала очень серьезно разобраться с этим" (5738s)
+
+        Стиль речи похож на ведущего. Учитывая что Bobuk из Яндекса и реплика про Яндекс.Войс,
+        возможно это Bobuk, ошибочно распознанный. Однако уверенности нет.
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Стиль ведущего, тема Яндекса, Bobuk работает в Яндексе"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Технические комментарии, активный участник"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5725.21
+          etime: 5737.89
+          text: "И все это, соответственно, что пользователь делает, что он ищет в этих смарт-оболочках, любимые программы и все такое прочее, это все дело сливалось туда."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 15
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Это не Пётр Диденко - метка говорит что присвоение было ошибочным и отменено
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Три реплики в разное время:
+        - "Вообще не очень этично, в принципе, на своего конкурента как-то возводить какие-то..." (268s)
+        - "А тут они могут что-то заработать даже" (1838s)
+        - "Ты учишься 5 лет в институте" (2674s)
+
+        Стиль похож на реплики ведущего в дискуссии.
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.4
+          reason: "Стиль комментариев, активный участник обсуждения"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Короткие комментарии в дискуссии"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 268.26
+          etime: 276.57
+          text: "Вообще не очень этично, в принципе, на своего конкурента как-то возводить какие-то... С другой же стороны, есть же свобода слова, правильно?"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 5
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Это не Лаваль - метка говорит что присвоение было ошибочным и отменено
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Три короткие реплики:
+        - "Ну, конечно, это очень дорого." (1087s)
+        - "Так, которые в онлайн же денег вроде не стоят." (1390s)
+        - "Это классная штука, мне кажется." (5143s)
+
+        Очень короткие реплики, похожи на ошибки распознавания или реплики в общем потоке.
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Короткие комментарии, может быть неправильно распознанная Марина"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Комментарии в дискуссии"
+
+      voice_task:
+        needed: false  # Слишком короткие реплики для сравнения
+        reference_segment: null
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 4
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Очень короткие односложные реплики (0.8-2 сек), разбросаны по выпуску - типичная ошибка распознавания"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Три односложные реплики:
+        - "Каждый день?" (3940s, 0.8 сек)
+        - "Почему?" (5164s, 0.8 сек)
+        - "Понятно." (6003s, 2.1 сек)
+
+        Это типичные короткие вставки, которые распознаватель не смог атрибутировать.
+        Скорее всего это реплики одного из ведущих (Gray, Marin_k_a или Umputun).
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.4
+          reason: "Короткие уточняющие реплики во время обсуждения"
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "Короткие реакции"
+
+      voice_task:
+        needed: false  # Слишком короткие реплики для надёжного сравнения
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Marin_k_a"
+      issue: |
+        Umputun обращается к спикеру как "Ксюша", но это Марина (Marin_k_a).
+        Ksenks начала участвовать только с выпуска 409, поэтому в 367 её быть не могло.
+        Возможно "Ксюша" - прозвище Марины или Umputun шутит/ошибается в обращении.
+        Требует уточнения - проверить другие выпуски с Marin_k_a на предмет обращения.
+
+    - speaker: "Bobuk"
+      issue: |
+        Bobuk присутствует минимально (8 реплик, 19 сек). В начале Umputun говорит
+        "без нашего индюка" и спрашивает "где Бобок". Bobuk ответил "Далеко очень".
+        Вероятно Bobuk был на связи недолго или только наблюдал. Нужно проверить,
+        не атрибутированы ли его реплики как SPEAKER_MISATTRIBUTED_*.
+
+# Предлагаемые правила очистки
+suggested_rules: []
+# Пока нет достаточной уверенности для автоматической переатрибуции.
+# Требуется voice comparison для SPEAKER_MISATTRIBUTED_ELDAR и SPEAKER_MISATTRIBUTED_PETR.
+
+# Задания на следующий этап
+next_steps:
+  - type: voice_comparison
+    speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    compare_with: [Bobuk, Gray]
+    reference_audio_time: "1:35:25-1:35:38"  # 5725-5738s
+
+  - type: voice_comparison
+    speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    compare_with: [Gray, Bobuk]
+    reference_audio_time: "0:04:28-0:04:36"  # 268-276s
+
+  - type: research
+    question: "Как Umputun обращается к Marin_k_a в других выпусках? Называет ли её Ксюшей?"
+    check_episodes: [365, 366, 368, 369]

--- a/validation/episodes/0300-0399/0368.yaml
+++ b/validation/episodes/0300-0399/0368.yaml
@@ -1,0 +1,213 @@
+episode: 368
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray, Bobuk]
+  guests_present: [Marin_k_a, EldarMurtazin]
+  total_duration_sec: 6414  # Based on Bobuk's last reply at ~6407s
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 521
+    replies_count: 209
+    pattern: consecutive  # Часто говорит несколько реплик подряд
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. Umputun обращается к кому-то как "Ксюша" (многократно, ~40 раз в выпуске)
+        2. SPEAKER_01 и Marin_k_a чередуются в диалогах как два разных человека
+        3. Marin_k_a уже идентифицирована как Марина в people.yaml
+        4. SPEAKER_01 говорит от первого лица женского рода: "Я поняла уже", "Даже когда приходила раньше"
+        5. Значительное присутствие (209 реплик, 521 сек) соответствует роли ведущей
+
+      possible_matches: []
+
+      voice_task:
+        needed: false  # Высокая уверенность в идентификации
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 566
+    replies_count: 110
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "registry"
+      confidence: high
+      evidence: "Уже присутствует в people.yaml как бывшая ведущая Марина"
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 140
+    replies_count: 31
+    pattern: scattered  # Появляется в разных частях выпуска
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "eldar_murtazin"
+      identification_method: "registry"
+      confidence: high
+      evidence: "Уже присутствует в people.yaml как известный мобильный аналитик"
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 6
+    replies_count: 4
+    pattern: scattered  # 4 реплики в разные моменты: 1774s, 5693s, 6717s
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Очень короткие реплики (1-2.5 сек), разбросаны по выпуску.
+        Содержание: "Левши-то и не русские", "Полно всяких разных", "Почему?", "Чемодан не там."
+        Скорее всего ошибка распознавания - короткие вставки от кого-то из присутствующих.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Первые две реплики идут после вопроса Umputun о 'русских умельцах'"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Может быть Gray, плохо распознанный"
+
+      voice_task:
+        needed: false  # Слишком короткие сегменты для сравнения голосов
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 9
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Маркировка SPEAKER_MISATTRIBUTED_ указывает, что это уже было определено как ошибочная атрибуция.
+        Реплики: "К тому, что они объявили банкротами" (после вопроса к Ксюше) и "Лучше купить тогда Kindle"
+        По контексту это скорее всего Ksenks или Marin_k_a.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "Umputun спрашивает 'А к чему все это, Ксюша?' и следом идёт этот ответ"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Также присутствует в диалоге"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2606.74
+          etime: 2613.68
+          text: "К тому, что они объявили, или точнее, их объявили банкротами."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Маркировка SPEAKER_MISATTRIBUTED_ указывает на ошибочную атрибуцию.
+        Единственная реплика "Вот так знали, что 4 части" (212.9s) - короткая ремарка в середине речи Umputun.
+        Скорее всего это ошибка распознавания голоса Umputun или одной из ведущих.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.5
+          reason: "Реплика идёт в середине монолога Umputun, может быть его же голос"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Короткая реакция, могла быть от кого-то из ведущих"
+
+      voice_task:
+        needed: false  # Слишком короткий сегмент (2 сек)
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_01"
+      issue: |
+        Не представлена явно, но идентифицирована как Ksenks по контексту обращений.
+        Рекомендуется переименовать SPEAKER_01 -> Ksenks.
+    - speaker: "Bobuk"
+      issue: |
+        Появляется только с 888 секунды (15 минут), всего 8 реплик за 37 сек.
+        Umputun в начале говорит "Бобука нет" - похоже, Bobuk подключился позже.
+        Низкая активность может указывать на ошибки атрибуции или на то, что он присоединился удалённо.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 368
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun многократно обращается к кому-то как "Ксюша", SPEAKER_01 отвечает.
+      Marin_k_a уже идентифицирована как Марина, это другой человек.
+      SPEAKER_01 говорит от женского лица и участвует активно (209 реплик).
+
+  - type: delete_or_merge
+    episode: 368
+    from_speaker: "SPEAKER_02"
+    to_speaker: null  # Требуется ручная проверка
+    confidence: low
+    reason: |
+      Только 4 коротких реплики (6 сек). Вероятно ошибки распознавания.
+      Рекомендуется ручная проверка аудио для определения реального спикера.
+
+  - type: review_needed
+    episode: 368
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"  # Предположительно
+    confidence: medium
+    reason: |
+      Первая реплика идёт прямо после обращения "Ксюша" от Umputun.
+      Требуется voice comparison для подтверждения.
+
+  - type: review_needed
+    episode: 368
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    to_speaker: null
+    confidence: low
+    reason: |
+      Единственная короткая реплика (2 сек). Слишком мало данных для идентификации.

--- a/validation/episodes/0300-0399/0369.yaml
+++ b/validation/episodes/0300-0399/0369.yaml
@@ -1,0 +1,267 @@
+episode: 369
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray, Bobuk]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7568  # ~2h 6min estimated
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 1621
+    replies_count: 364
+    pattern: consecutive
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: null
+      identification_method: "introduction"
+      confidence: high
+      evidence: >
+        При представлении Umputun спрашивает "Виктор, а у тебя как? Ты Виктор и ты программист на джаве?"
+        SPEAKER_05 отвечает "Нет, я шоумен, зачем? У меня же отдельное шоу, все его знают.
+        Даже Великий Ампутунг нам заходил один раз."
+        Позже Umputun говорит "Ты, Виктор, в ID живёшь или в Eclipse?"
+        Это гость по имени Виктор, у которого своё шоу, возможно подкастер.
+      possible_matches: []
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 242.15
+          etime: 255.43
+          text: >
+            У нас, понимаешь, у нас объем информации слишком большой за выпуск,
+            поэтому мы ее как-то размазываем по две недельки.
+            Мы не каждую неделю выходим, мы каждые две недели в основном.
+    suggested_name: "Viktor"
+    suggested_real_name: "Виктор"
+    suggested_info: "Подкастер, Java-разработчик, выпуск 369"
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 701
+    replies_count: 171
+    pattern: consecutive
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: null
+      identification_method: "introduction"
+      confidence: high
+      evidence: >
+        Явное представление в начале выпуска (100.8s):
+        "Здравствуйте, я Роман. Работаю в Dell. Был у вас тут один раз.
+        Про OpenStack рассказывал. Тогда еще работал в Barclay."
+        Повторный гость, ранее рассказывал про OpenStack.
+      possible_matches: []
+      voice_task:
+        needed: false  # Чётко представился, можно искать в предыдущих выпусках
+        reference_segment: null
+    suggested_name: "Roman"
+    suggested_real_name: "Роман"
+    suggested_info: "Работает в Dell, ранее Barclay, специалист по OpenStack, выпуски 369 и предыдущий"
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 255
+    replies_count: 70
+    pattern: consecutive
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: null
+      identification_method: "introduction"
+      confidence: high
+      evidence: >
+        Явное представление (185.9s-192.6s):
+        "Добрый вечер. Меня зовут Андрей. Я джава-разработчик. Работаю в Deutsche Bank."
+        Umputun реагирует "Здравствуй, Андрей!"
+      possible_matches: []
+      voice_task:
+        needed: false  # Чётко представился
+        reference_segment: null
+    suggested_name: "AndreyDeutscheBank"
+    suggested_real_name: "Андрей"
+    suggested_info: "Java-разработчик, Deutsche Bank, выпуск 369"
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 308
+    replies_count: 117
+    pattern: scattered
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: >
+        Женский голос (77.5s: "Я с конями так представила").
+        Umputun в начале эпизода обращается "Ксюша" (15.3s, 42.7s).
+        SPEAKER_04 отвечает на обращения к Ксюше, активно участвует в техническом обсуждении.
+        Однако в этом же эпизоде есть Marin_k_a (тоже женщина).
+        Возможна путаница между Ksenks и кем-то другим.
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: "Umputun обращается 'Ксюша', SPEAKER_04 отвечает женским голосом"
+        - person_id: "marin_k_a"
+          confidence: 0.2
+          reason: "Marin_k_a уже размечена отдельно, маловероятно"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 77.53
+          etime: 82.2
+          text: "Я с конями так представила. Потому что как зубы голову на бок."
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 108
+    replies_count: 13
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: >
+        Контекст реплик - технические обсуждения JetBrains IDE, плагины, PyCharm.
+        Эльдар Муртазин - мобильный аналитик, не Java-разработчик.
+        Реплики идут в середине разговора между SPEAKER_05 (Виктор) и Umputun об IDE.
+        Скорее всего это ошибка распознавания, реплики принадлежат SPEAKER_05 (Виктор).
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: >
+        Пример реплики (404.2s): "Тебе просто пойдёшь, поставишь плагин через их репозиторий, и все, и вперед."
+        Это продолжение разговора о JetBrains, который ведёт SPEAKER_05 (Виктор).
+      possible_matches:
+        - person_id: "viktor"
+          confidence: 0.8
+          reason: "Контекст - продолжение речи SPEAKER_05 об IDE"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1123.18
+          etime: 1130.01
+          text: >
+            Когда ты запускаешь, у тебя пустой вордспейс, ничего нет, да,
+            и у тебя такой, сейчас он серенький такой, клевый, в стиле Маверикса
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 11
+    replies_count: 2
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: "Уже помечен как ошибочно приписанный. Короткие фрагменты в случайных местах."
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "2 короткие реплики в разных частях подкаста (6429s, 6959s)"
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 1
+    replies_count: 2
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: >
+        Очень короткие фразы (менее 1 сек суммарно) в разных частях подкаста.
+        Типичные фразы-ошибки: "Больше седьмого, да." (29.4s), "Да." (8392s).
+        Вероятно ошибка распознавания кого-то из участников.
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "2 односложные реплики в разных частях"
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_04"
+      issue: >
+        Не представлен явно. По контексту похож на Ksenks (обращения "Ксюша"),
+        но требует voice comparison для подтверждения.
+    - speaker: "EldarMurtazin"
+      issue: >
+        Ошибочная разметка! Эльдар Муртазин не участвовал в этом выпуске.
+        Реплики относятся к техническому обсуждению IDE, скорее всего это SPEAKER_05 (Виктор).
+    - speaker: "Bobuk"
+      issue: >
+        Только 1 реплика (1216s). Возможно Bobuk был кратко или это ошибка распознавания.
+        Требует проверки - был ли Bobuk объявлен как участник выпуска.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 369
+    from_speaker: "EldarMurtazin"
+    to_speaker: "SPEAKER_05"
+    confidence: high
+    reason: >
+      Реплики EldarMurtazin идут в контексте технического обсуждения JetBrains IDE,
+      которое ведёт SPEAKER_05 (Виктор). Эльдар Муртазин - мобильный аналитик,
+      такие реплики ему не характерны. Ошибка автоматической разметки.
+
+  - type: rename
+    episode: 369
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: >
+      Женский голос, отвечает на обращения "Ксюша". Требует voice comparison
+      для окончательного подтверждения, так как в эпизоде есть и Marin_k_a.
+
+  - type: remove_or_reassign
+    episode: 369
+    from_speaker: "SPEAKER_03"
+    to_speaker: null
+    confidence: medium
+    reason: >
+      Всего 2 односложные реплики (<1 сек суммарно). Вероятно ошибка распознавания,
+      нужно определить кому они принадлежат по контексту.
+
+# Новые гости для добавления в people.yaml
+new_guests_to_register:
+  - id: "viktor_podkaster"
+    canonical_name: "Viktor"
+    real_name: "Виктор"
+    info: "Подкастер с собственным шоу, Java-разработчик, выпуск 369"
+    notes: "Требует уточнения фамилии и названия шоу"
+
+  - id: "roman_dell"
+    canonical_name: "Roman"
+    real_name: "Роман"
+    info: "Работает в Dell (ранее Barclay), специалист по OpenStack, повторный гость"
+    notes: "Нужно найти предыдущий выпуск с его участием"
+
+  - id: "andrey_deutschebank"
+    canonical_name: "AndreyDeutscheBank"
+    real_name: "Андрей"
+    info: "Java-разработчик, Deutsche Bank, выпуск 369"
+
+# Резюме
+summary: |
+  Эпизод 369 (7 декабря 2013) - выпуск с несколькими гостями:
+
+  Ведущие: Umputun (основной), Gray (с 532s), Bobuk (1 реплика, возможно ошибка)
+
+  Идентифицированные гости:
+  - Marin_k_a (Марина) - уже размечена, бывшая ведущая
+  - SPEAKER_02 = Роман (Dell, OpenStack) - чётко представился
+  - SPEAKER_00 = Андрей (Java, Deutsche Bank) - чётко представился
+  - SPEAKER_05 = Виктор (подкастер, Java) - идентифицирован по контексту
+
+  Требуют проверки:
+  - SPEAKER_04 - вероятно Ksenks, но нужен voice comparison
+  - EldarMurtazin - ОШИБКА! Это не Эльдар, а скорее всего Виктор
+
+  Ошибки распознавания:
+  - SPEAKER_03 - артефакт (2 односложные реплики)
+  - SPEAKER_MISATTRIBUTED_LAVALE - уже помечен как ошибка

--- a/validation/episodes/0300-0399/0370.yaml
+++ b/validation/episodes/0300-0399/0370.yaml
@@ -1,0 +1,279 @@
+episode: 370
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  # Ksenks была на записи (обращения "Ксюша"), но размечена как Marin_k_a
+  # Gray НЕ был на записи (в начале говорят "сейчас придёт Грей")
+  total_duration_sec: 7014
+  notes: >
+    В начале подкаста Umputun говорит "сейчас придёт Грей" и "как мы, Ксюша, с тобой вдвоем" -
+    это означает что Gray НЕ участвовал, а Ksenks (Ксюша) была. Но Ksenks ошибочно
+    размечена как Marin_k_a.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 813
+    replies_count: 148
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Это НЕ Марина (Marin_k_a), а Ksenks. Доказательства:
+        1. Umputun многократно обращается "Ксюша" к этому спикеру (строки 91, 334, 541, 1099, и др.)
+        2. В начале подкаста: "как мы, Ксюша, с тобой вдвоем, это будет игра в одни ворота"
+        3. Женский род речи ("я привыкла", "я осилила")
+        4. Marin_k_a (Марина) - бывшая ведущая, не участвовала в эпизоде 370
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: >
+        Прямые обращения: "Ксюша, ты эту первую тему смогла прочитать?" (145s),
+        "как мы, Ксюша, с тобой вдвоем" (23s), "Вот Ксюша не знает" (439s) и ещё ~20 обращений по имени
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 446
+    replies_count: 206
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Часть реплик Ksenks, разделённых из-за ошибки распознавания.
+        SPEAKER_01 и Marin_k_a (=Ksenks) чередуются в быстром диалоге,
+        продолжая мысли друг друга. Примеры:
+        - 134.0s SPEAKER_01: "Как же ты пропустил?" -> 134.8s Marin_k_a: "Ты не ходил на праздник?"
+        - 1681.6s Marin_k_a: "Я тоже привыкла..." -> 1693.2s SPEAKER_01: "Но окей, спасибо Гуглу"
+        Короткие подтверждающие реплики типа "Ну да", "Да, да, да" - типичные для перебивок одного человека
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: >
+        206 реплик распределены по всему подкасту (134s-7005s), чередуясь с Marin_k_a.
+        Контекст разговоров показывает что это один человек (Ksenks), разделённый на два тега.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 146
+    replies_count: 25
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "mark_shuttleworth_video"
+          confidence: 0.95
+          reason: >
+            Это НЕ живой гость, а переведённое видео-интервью с Марком Шаттлвортом.
+            Контекст: Bobuk говорит "Мы с Марком Шатубортом... на конференции в Париже" (2206s),
+            затем идут реплики SPEAKER_00 про Ubuntu Mobile с характерным "переводным" стилем
+            ("персональное компьютерное обучение" = personal computing).
+
+      voice_task:
+        needed: false
+        note: "Не требуется - это воспроизведение видеозаписи, не живой гость"
+
+  - speaker: "Gray"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Gray НЕ участвовал в этом эпизоде. В начале Umputun говорит "сейчас придёт Грей",
+        в конце спрашивают "Грей вернётся в семью?". Единственная реплика (2825s)
+        "Я большой специалист в этой области" - продолжение речи Bobuk:
+        "Так анонсировать можно всё что угодно... [Gray] Я большой специалист в этой области...
+        [Bobuk] я тебе могу честно об этом сказать"
+
+      identified_as: "bobuk"
+      identification_method: "context"
+      confidence: high
+      evidence: >
+        Реплика между двумя репликами Bobuk, продолжает его мысль.
+        Gray отсутствовал на записи (подтверждено в начале и конце подкаста).
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 6
+    replies_count: 6
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Короткие реплики-подтверждения ("Да, работы Java", "Верно", "Ну да", "Как оно?", "Да, конечно")
+        разбросанные по подкасту. Типичные короткие перебивки одного из ведущих.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "Короткие подтверждения, похожи на остальные реплики Ksenks в этом эпизоде"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Могут быть и репликами Bobuk"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5707.07
+          etime: 5708.11
+          text: "Ну да. Как оно?"
+        note: "Слишком короткие реплики для надёжной идентификации"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 7
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Тег указывает на отменённое присвоение к Lavale. Lavale - бывшая ведущая,
+        не участвовала в эпизоде 370. Реплики скорее всего принадлежат Ksenks или одному из ведущих.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: "Контекст реплик и время появления совпадает с активностью Ksenks"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 788.16
+          etime: 792.0
+          text: "То есть раньше это были, ну, сейчас это люди, да, которые пишут на PL, SQL."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 6
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Тег указывает на отменённое присвоение к Eldar (Эльдар Муртазин).
+        Эльдар не участвовал в эпизоде 370. Короткие реплики скорее всего
+        принадлежат одному из присутствующих ведущих.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Реплики появляются в контексте технических обсуждений где активен Bobuk"
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Могут быть частью разделённых реплик Ksenks"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1756.08
+          etime: 1757.82
+          text: "Ну вот, собственно говоря, Google их купил."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Marin_k_a"
+      issue: >
+        Неверная атрибуция: Marin_k_a - это Марина (бывшая ведущая), но в этом эпизоде
+        это на самом деле Ksenks. Umputun ~20 раз обращается к этому спикеру как "Ксюша".
+
+    - speaker: "Gray"
+      issue: >
+        Gray не участвовал в эпизоде (явно сказано в начале и конце).
+        Единственная реплика - ошибка распознавания, принадлежит Bobuk.
+
+    - speaker: "SPEAKER_01"
+      issue: >
+        206 реплик без идентификации, но это тот же человек что Marin_k_a (=Ksenks).
+        Реплики нужно объединить.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 370
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: >
+      Umputun многократно обращается к этому спикеру как "Ксюша".
+      Marin_k_a (Марина) не участвовала в записи.
+
+  - type: rename
+    episode: 370
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: >
+      SPEAKER_01 чередуется с Marin_k_a в быстрых диалогах, продолжая те же мысли.
+      Это часть реплик того же человека (Ksenks), разделённых ошибкой распознавания.
+
+  - type: rename
+    episode: 370
+    from_speaker: "Gray"
+    to_speaker: "Bobuk"
+    confidence: high
+    reason: >
+      Gray не участвовал в эпизоде. Единственная реплика (2825s) - продолжение
+      речи Bobuk между его двумя другими репликами.
+
+  - type: rename
+    episode: 370
+    from_speaker: "SPEAKER_00"
+    to_speaker: "_video_shuttleworth"
+    confidence: high
+    reason: >
+      Это не гость, а воспроизведение переведённого видео-интервью с Марком Шаттлвортом.
+      Контекст явно указывает на запись конференции.
+
+  - type: review_needed
+    episode: 370
+    speakers: ["SPEAKER_02", "SPEAKER_MISATTRIBUTED_LAVALE", "SPEAKER_MISATTRIBUTED_ELDAR"]
+    confidence: medium
+    reason: >
+      Короткие реплики (всего 19 сек суммарно), требуют voice comparison для точной атрибуции.
+      Вероятно принадлежат Ksenks или Bobuk.
+
+# Аудио для voice comparison
+audio_url: null  # Метаданные не найдены в data_clean/370/370_desc.json

--- a/validation/episodes/0300-0399/0371.yaml
+++ b/validation/episodes/0300-0399/0371.yaml
@@ -1,0 +1,210 @@
+episode: 371
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 6581  # ~1h 50min based on speaker stats
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 397
+    replies_count: 185
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Multiple direct name calls with immediate responses:
+        - 2159s: Umputun "Наверное, Ксюша, ты ходила" -> SPEAKER_04 "Да, я ходила"
+        - 2375s: Gray "Ксюша, видела видео?" -> SPEAKER_04 "Да, я видела"
+        - 1197s: SPEAKER_04 responds in dialogue about tech topics as active participant
+        Pattern: Consistent female voice throughout episode, addressed as "Ксюша"
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Single word 'русский' (216.5s) between Gray's utterances. Likely a fragment of Gray's speech incorrectly split by ASR."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.9
+          reason: "Fragment appears mid-sentence in Gray's monologue about translation"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 21
+    replies_count: 10
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Previously misattributed to EldarMurtazin. Eldar does not appear in this episode (371, Dec 2013). These are likely host utterances incorrectly identified."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Examples of misattributed speech:
+        - 369s: "Они его закатили довольно быстро, кстати" - tech discussion context
+        - 1168s: "Подожди, как на 10?" - question in dialogue with Gray
+        Short interjections that could be any host.
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Some interjections match Bobuk's style"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Contextual proximity to Gray's speech"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Could be any host"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 369.86
+          etime: 371.64
+          text: "Они его закатили довольно быстро, кстати."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 22
+    replies_count: 5
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Previously misattributed to Lavale. Lavale does not appear in this episode. These are likely host utterances incorrectly identified."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Examples:
+        - 936s: "Понятное дело, что если есть технологии, то есть люди, которые хотят ими пользоваться"
+        - 1930s: "Ну, то есть они делают только маленькую коробочку, в которую ты сам втыкаешь сво..."
+        These are substantive comments in discussion context.
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Female voice, substantive tech commentary"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Could be Ksenks"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 936.71
+          etime: 940.81
+          text: "Понятное дело, что если есть технологии, то есть люди, которые хотят ими пользоваться."
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 678
+    replies_count: 146
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Marin_k_a (Marina) is a known former host. However, there's potential confusion:
+        - At 25s: Umputun addresses "Ксюша" about being late, Marin_k_a responds
+        - At 238s: Umputun asks "Ксюша" about disappointments, Marin_k_a responds
+        This may indicate some of Marin_k_a's lines actually belong to Ksenks.
+
+        However, there are clear dialogues where BOTH Marin_k_a and SPEAKER_04 (Ksenks)
+        speak in sequence (e.g., 1208-1223s, 2163-2195s), confirming they are different people.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_04"
+      issue: "Not explicitly introduced at start, but consistently addressed as 'Ксюша' throughout. Should be renamed to Ksenks."
+
+    - speaker: "Marin_k_a"
+      issue: "Responds to 'Ксюша' address at 25s and 238s, but Ксюша is Ksenks's nickname. Possible misattribution of some early Ksenks lines to Marin_k_a, OR Umputun addressed wrong person."
+
+    - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+      issue: "10 orphaned utterances from incorrect Eldar attribution. Need voice comparison to identify actual speaker."
+
+    - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+      issue: "5 orphaned utterances from incorrect Lavale attribution. Need voice comparison to identify actual speaker."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 371
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Direct name addressing: 'Ксюша, ты ходила' -> 'Да, я ходила'; 'Ксюша, видела?' -> 'Да, я видела'. Ksenks is canonical name for Ксюша."
+
+  - type: rename
+    episode: 371
+    from_speaker: "SPEAKER_03"
+    to_speaker: "Gray"
+    confidence: medium
+    reason: "Single word fragment between Gray's sentences, likely ASR split error."
+
+# Примечания для ручной проверки
+notes: |
+  1. SPEAKER_04 -> Ksenks: HIGH confidence rename. Multiple direct name-response pairs.
+
+  2. Potential issue with early Marin_k_a lines (25s-59s):
+     Umputun says "Хорошо, Ксюша, что ты нам зашла... ты просто опоздала молча"
+     Marin_k_a responds about being ready and waiting.
+     This could mean:
+     a) Marin_k_a was also late and responded, not Ksenks
+     b) These lines are actually Ksenks misattributed to Marin_k_a
+     c) Both were present; Marin_k_a spoke up though Umputun addressed Ksenks
+
+     Recommendation: Voice comparison needed for 33-59s segment.
+
+  3. SPEAKER_MISATTRIBUTED_* entries indicate previously corrected errors.
+     These need voice comparison to properly attribute.
+
+  4. Episode has 4 participants: Umputun, Bobuk, Gray, and two female voices
+     (Marin_k_a and Ksenks). Total 5 active speakers + misattributed fragments.
+
+# Audio reference for voice comparison
+audio_url: null  # Check data/371/371_desc.json for CDN URL

--- a/validation/episodes/0300-0399/0372.yaml
+++ b/validation/episodes/0300-0399/0372.yaml
@@ -1,0 +1,244 @@
+episode: 372
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray, Ksenks, Marin_k_a]
+  total_duration_sec: 7001
+  notes: "Эпизод от 28 декабря 2013. В гостях представитель QuickBlocks (BaaS сервис)."
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 639
+    replies_count: 117
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: "Marin_k_a уже идентифицирована в транскрипте как Марина, бывшая ведущая. В people.yaml есть запись с id: marin_k_a"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 376
+    replies_count: 168
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Прямое подтверждение в строке 12421: Umputun спрашивает "Но я не понимаю, почему молчите вы, Ксения?" и в строке 12436 SPEAKER_03 отвечает: "Да, я изучаю следующую тему, а то меня же спросят, что дальше."
+        Также в строке 1432 Umputun говорит "Ксюша, у меня для тебя плохие новости есть" после реплики SPEAKER_03.
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_07"
+    total_duration_sec: 337
+    replies_count: 67
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Гость представляет сервис QuickBlocks (Backend as a Service).
+        Появляется в 2072 сек, Umputun приветствует: "Здравствуй, дорогой".
+        Не был представлен по имени в транскрипте.
+        Говорит про технические детали BaaS: "В общем, у нас QuickBlocks два в одном. Это BaaS и Communication as a Service."
+      possible_matches:
+        - person_id: "quickblocks_guest"
+          confidence: 0.3
+          reason: "Представитель стартапа QuickBlocks, имя неизвестно"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2329.57
+          etime: 2360.86
+          text: "Есть куча сервисов для Push Notifications, например, Urban Airship, можно на Амазоне свой поднять. Но опять же, вы хотите админку сделать, сертификаты подписывать, очередь, queue service и так далее. Потом, естественно, потребуется чат, инфикация юзеров, location, различные другие API, сохранение файлов. И все это вместе, все в одном, естественно, называется Backend as a Service. Но мы сейчас делали фокус на Communication..."
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 35
+    replies_count: 17
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибка распознавания голоса Ksenks. Короткие реплики, перемежающиеся с SPEAKER_03 (тоже Ksenks). Паттерн: отвечает на обращения к Ксюше, но реже чем SPEAKER_03."
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Строка 12574: Umputun говорит "Ксюша, ты так и не понял, о чем он говорит..."
+        Строка 12580: SPEAKER_02 отвечает "А Бобук понял?"
+        Реплики короткие: "Нет", "А почему для девочек не работает?", "Ты меня пугаешь"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 23
+    replies_count: 9
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Реплики ранее ошибочно атрибутированы EldarMurtazin. Эльдар не участвовал в этом выпуске. Требуется определить реального автора."
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Примеры: 'Ну, как обычно же.', 'Очень хорошо возразил Ом Малик.' - похоже на голос одного из ведущих"
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Возможно та же ошибка распознавания что и SPEAKER_02/SPEAKER_03"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Могла быть ошибочно распознана"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 326.36
+          etime: 329.98
+          text: "Очень хорошо возразил Ом Малик."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 22
+    replies_count: 6
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Реплики ранее ошибочно атрибутированы Lavale. Лаваль не участвовала в этом выпуске. Требуется определить реального автора."
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Примеры: 'Как раз в тему, что покупки заменяют инновации.', 'Что Google не хочет растить внутри себя инновации...' - осмысленные комментарии по теме"
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Тематика реплик совпадает с участием Ksenks в обсуждении"
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "Марина активно участвует в обсуждении IT-тем"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1120.9
+          etime: 1129.35
+          text: "Как раз в тему, что покупки заменяют инновации. Что Google не хочет растить внутри себя инновации, а хочет, видимо, их покупать."
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 16
+    replies_count: 10
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие односложные реплики, разбросанные по эпизоду. Типичные ошибки автоматического распознавания."
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Примеры: 'Как?', 'Пьют, конечно.', 'И дома пьют.', 'Не, ну это пилгейт, вроде все честно.'"
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Женский голос в контексте разговора"
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "Женский голос в контексте разговора"
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 3
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Очень короткие реплики (1-2 сек), типичные ошибки распознавания: 'Вот что-то ты сломал.', 'Раздавят.'"
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Артефакт. Единственная реплика 'Ну-ну-ну-ну-ну-ну-ну.' в 6610 сек - похоже на звуковой эффект или помеху."
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches: []
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_07"
+      issue: "Гость из QuickBlocks не был представлен по имени. Umputun приветствует его как 'дорогой' в 2069 сек."
+    - speaker: "Ksenks"
+      issue: "Ксюша упоминается 20+ раз по имени, но атрибутирована как SPEAKER_03 (168 реплик) и частично SPEAKER_02 (17 реплик). Требуется объединение."
+    - speaker: "SPEAKER_MISATTRIBUTED_*"
+      issue: "Присутствуют метки ошибочной атрибуции (ELDAR, LAVALE), требуется определить реальных авторов."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 372
+    from_speaker: "SPEAKER_03"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Прямое подтверждение: обращение 'Ксения' с ответом SPEAKER_03"
+
+  - type: rename
+    episode: 372
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: "Ответы на обращения к Ксюше, короткие реплики - вероятно та же ошибка распознавания"
+
+  - type: rename
+    episode: 372
+    from_speaker: "SPEAKER_04"
+    to_speaker: "SPEAKER_99"
+    confidence: high
+    reason: "Артефакт: 'Ну-ну-ну-ну-ну-ну-ну' - не речь"
+
+  - type: manual_review
+    episode: 372
+    speakers: ["SPEAKER_MISATTRIBUTED_ELDAR", "SPEAKER_MISATTRIBUTED_LAVALE", "SPEAKER_00", "SPEAKER_01"]
+    reason: "Требуется voice comparison для определения реальных авторов"
+
+  - type: add_guest
+    episode: 372
+    speaker: "SPEAKER_07"
+    suggested_id: "quickblocks_guest_372"
+    reason: "Представитель QuickBlocks, имя не было названо в эфире. Требуется внешнее исследование для идентификации."
+
+# Аудио для voice comparison
+audio_reference:
+  url: null  # Метаданные не найдены в data_clean, требуется проверка в data/
+  episode_date: "2013-12-28"

--- a/validation/episodes/0300-0399/0373.yaml
+++ b/validation/episodes/0300-0399/0373.yaml
@@ -1,0 +1,273 @@
+episode: 373
+status: needs_review
+analyzed_at: "2026-01-25T12:00:00Z"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  # Примечание: Ksenks НЕ присутствует как author в транскрипте,
+  # но ведущие обращаются к "Ксюше" - отвечают Marin_k_a и SPEAKER_00
+  total_duration_sec: 11000  # приблизительно ~3 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 1963
+    replies_count: 379
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: null
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        В начале выпуска (строка 34-41, 118) Umputun говорит: "гость из дружественного подкаста".
+        В строке 550 Umputun обращается: "Алексей, пока мы не отошли далеко от этой темы...".
+        В строке 586 упоминается: "Скорее всего, Абашев".
+        Это указывает на гостя по имени Алексей, возможно связанного с Антоном Абашевым.
+
+        SPEAKER_01 активно участвует в технических дискуссиях:
+        - Облачные сервисы Amazon (Китай, CloudFront)
+        - Юнит-тестирование, CI/CD, проблемы с моками
+        - Безопасность и backdoors
+        - Stack Overflow
+
+        Суммарно говорит ~1963 сек (13% эпизода) - это полноценный гость.
+
+      possible_matches:
+        - person_id: "alek_sys"
+          confidence: 0.3
+          reason: "Имя Алексей, технические темы. Но Alek.sys - постоянный ведущий, не гость."
+        - person_id: null
+          confidence: 0.6
+          reason: |
+            Возможно это Алексей из подкаста AppleInsider.ru (связан с Антоном Абашевым).
+            Требуется добавить в people.yaml или уточнить по голосу.
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1345
+          etime: 1371
+          text: "А вот тебя не пугает, что, опять же, да, я недавно ссылка прошла, что Амазон запустился в Китае, и там они предоставляют отдельный аккаунт, где надо указать, что это происходит, что этот юзер в Китае..."
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 564
+    replies_count: 99
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "known_speaker"
+      confidence: high
+      evidence: |
+        Marin_k_a присутствует в people.yaml как бывшая ведущая Марина.
+        Однако есть несоответствие: Umputun обращается к "Ксюше" (строка 154),
+        а отвечает Marin_k_a (строка 161). Это может означать:
+        1. Марина также известна как "Ксюша" (маловероятно)
+        2. Ошибка разметки - часть реплик Ksenks размечены как Marin_k_a
+        3. В этом выпуске действительно была Марина, а не Ксения
+
+        Вывод: Marin_k_a - корректная разметка, но требуется проверка
+        консистентности с обращениями "Ксюша".
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 339
+    replies_count: 136
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        В строке 8695-8704: Bobuk говорит "Ксюша замолчала", затем SPEAKER_00 отвечает "Да, да, знаю."
+        Это прямое указание, что SPEAKER_00 = Ksenks (Ксюша).
+
+        Также в начале выпуска (строка 178-181): Umputun спрашивает "Смотрела телевизор?",
+        SPEAKER_00 отвечает "У меня нет телевизора" - продолжение диалога с "Ксюшей".
+
+        Однако Ksenks отсутствует в списке авторов этого эпизода.
+        Видимо часть её реплик размечены как SPEAKER_00, часть как Marin_k_a.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.85
+          reason: "Прямое обращение по имени 'Ксюша' с ответом от SPEAKER_00"
+        - person_id: "marin_k_a"
+          confidence: 0.15
+          reason: "Возможно это та же женщина, что и Marin_k_a (ошибка сегментации)"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 82.6
+          etime: 97.93
+          text: "В смысле, то есть ты, если переезжаешь границу, то сразу президент меняется? У тебя так? Да? Интересно. [...] В общем, не видела президента."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 14
+    replies_count: 5
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие реплики (1-4 сек) в случайные моменты.
+        Маркер MISATTRIBUTED указывает на отменённое ошибочное присвоение Эльдару Муртазину.
+        Эти реплики скорее всего принадлежат SPEAKER_01 или другим участникам.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 4
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Очень короткие реплики ("А, можно, можно.", "Можно, можно.", "У меня прям противоположный опыт.")
+        Всего 4 секунды на 3 реплики. Скорее всего ошибка сегментации -
+        это фрагменты речи других участников.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 14
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одна реплика 14 секунд в 9196s. Маркер MISATTRIBUTED указывает
+        на отменённое ошибочное присвоение Петру Диденко.
+        Реплика про "жену айтишника" - скорее всего принадлежит одному из гостей.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одна очень короткая реплика (2 сек). Маркер MISATTRIBUTED указывает
+        на отменённое ошибочное присвоение Лаваль.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_01"
+      issue: |
+        Гость представлен как "из дружественного подкаста", назван "Алексеем",
+        упомянут "Абашев". Но имя не указано явно в начале.
+        Требуется идентификация: возможно Алексей из AppleInsider.ru.
+
+    - speaker: "Marin_k_a / SPEAKER_00"
+      issue: |
+        Ведущие обращаются к "Ксюше", но в разметке нет Ksenks.
+        Ответы идут от Marin_k_a и SPEAKER_00.
+        Возможные объяснения:
+        1. SPEAKER_00 = Ksenks, Marin_k_a = Марина (две разные женщины)
+        2. Marin_k_a = Ksenks (ошибка в имени автора)
+        3. Ошибка сегментации - одна женщина, два спикера
+
+        Требуется voice comparison для разрешения.
+
+    - speaker: "Gray"
+      issue: |
+        Gray присутствует, первая реплика только в 271s.
+        Это нормально - его представляют позже в выпуске.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 373
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      Прямой контекст: "Ксюша замолчала" -> SPEAKER_00 отвечает.
+      Требуется voice comparison для подтверждения.
+
+  - type: merge
+    episode: 373
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "SPEAKER_01"  # или другой участник
+    confidence: low
+    reason: |
+      Короткие реплики, скорее всего принадлежат соседним спикерам.
+      Требуется ручной просмотр контекста каждой реплики.
+
+# Дополнительные примечания
+notes: |
+  Эпизод 373 от 4 января 2014 года - первый выпуск 2014 года.
+
+  Основные проблемы:
+  1. SPEAKER_01 - неидентифицированный гость "Алексей" (1963 сек, 379 реплик)
+  2. Несоответствие Marin_k_a/SPEAKER_00 и обращений к "Ксюше"
+  3. Мелкие ошибки сегментации (SPEAKER_03, MISATTRIBUTED_*)
+
+  Приоритеты для следующих шагов:
+  1. Voice comparison для SPEAKER_01 - определить кто такой "Алексей"
+  2. Voice comparison для SPEAKER_00 vs Ksenks
+  3. Проверить консистентность Marin_k_a в других эпизодах

--- a/validation/episodes/0300-0399/0374.yaml
+++ b/validation/episodes/0300-0399/0374.yaml
@@ -1,0 +1,232 @@
+episode: 374
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [PetrDidenko, Marin_k_a]
+  total_duration_sec: ~7840
+
+# Важное замечание: Ksenks отсутствует как отдельный спикер (0 реплик),
+# но в начале эпизода упоминается "Ксюша" и SPEAKER_00 обращаются как к Ксюше.
+# Это указывает на то, что SPEAKER_00 - это Ksenks.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 361
+    replies_count: 135
+    pattern: consecutive
+    first_appearance_sec: 76.3
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: >
+        1) В начале (17.8s) Umputun: "Ксюша привела с собой мальчика"
+        2) После реплики SPEAKER_00 (172.4s) "Мне кажется, забавно" Umputun отвечает (173.9s): "Мне бы твой оптимизм, Ксюша"
+        3) Ksenks как отдельный спикер имеет 0 реплик в эпизоде, хотя упоминается как участник
+        4) Реплики типичные для активного участника дискуссии, а не случайные вставки
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "PetrDidenko"
+    total_duration_sec: 916
+    replies_count: 298
+    pattern: consecutive
+    first_appearance_sec: 23.3
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "petr_didenko"
+      identification_method: "introduction"
+      confidence: high
+      evidence: >
+        Представлен в начале эпизода:
+        - (17.8s) Umputun: "Ксюша привела с собой мальчика. Здравствуй, мальчик."
+        - (23.3s) PetrDidenko: "Здравствуйте, девочки."
+        - (39.1s) Umputun: "Петя, хорошо, что зашел. Давно тебя не было."
+        - (42.8s) PetrDidenko: "Да, я, насколько я понимаю, где-то с августа..."
+        Полностью соответствует Пётру Диденко из people.yaml
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 324
+    replies_count: 64
+    pattern: consecutive
+    first_appearance_sec: 168.0
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: >
+        Marin_k_a - известный бывший ведущий (Марина) из people.yaml.
+        Активно участвует в дискуссиях на техническую тематику (iPhone, CentOS, Android).
+        Реплики осмысленные, длинные, встроены в диалог как полноценный участник.
+        Примеры: обсуждение iPhone (168s), CentOS сборки (3513s), Evernote (5343s).
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 33
+    replies_count: 7
+    pattern: scattered
+    first_appearance_sec: 722.5
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Маркер отменённого ошибочного присвоения. Реплики были ошибочно приписаны Эльдару Муртазину,
+        но он не участвует в этом эпизоде. Эти реплики разбросаны по эпизоду и скорее всего
+        принадлежат одному из ведущих или гостей с похожим голосом.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Некоторые реплики тематически близки к обычным комментариям Bobuk"
+        - person_id: "petr_didenko"
+          confidence: 0.3
+          reason: "Голос мог быть спутан, Петя - также мужской голос"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1160.77
+          etime: 1165.72
+          text: "И BlackBerry вообще считает, что они сейчас вот с клавиатурами порвут всех."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 14
+    replies_count: 4
+    pattern: scattered
+    first_appearance_sec: 739.9
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Маркер отменённого ошибочного присвоения. Реплики были ошибочно приписаны Lavale,
+        но Lavale (бывшая ведущая) не участвует в этом эпизоде.
+        Короткие реплики разбросаны по эпизоду.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Женский голос, тематика реплик близка к Марине"
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Женский голос, возможно ошибка распознавания Ксюши"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3408.96
+          etime: 3413.1
+          text: "Не как бы 'Интерпрайз', а просто 'Интерпрайз', где за 'Архел' платят?"
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 9
+    replies_count: 6
+    pattern: scattered
+    first_appearance_sec: 226.7
+
+    analysis:
+      is_error: true
+      error_reason: >
+        Очень короткие реплики (1-3 секунды) разбросаны случайным образом по эпизоду.
+        Типичные вставки: "И тебе не положено было радоваться", "На тему айфона", "Хорошо".
+        Это классический паттерн ошибок автоматического распознавания спикеров.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.4
+          reason: "Реплики встроены между репликами Gray и Bobuk, возможно Gray"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Похожи на короткие комментарии"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+        reason: "Слишком короткие реплики для voice comparison"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Ksenks"
+      issue: >
+        Ksenks как отдельный спикер имеет 0 реплик, но SPEAKER_00 (135 реплик)
+        идентифицируется как Ksenks по контексту. Рекомендуется переименование.
+    - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+      issue: >
+        7 реплик с маркером отменённого присвоения требуют переатрибуции.
+        Эльдар Муртазин не участвовал в этом эпизоде.
+    - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+      issue: >
+        4 реплики с маркером отменённого присвоения требуют переатрибуции.
+        Lavale не участвовала в этом эпизоде.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 374
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: >
+      Прямое обращение "Ксюша" после реплики SPEAKER_00,
+      отсутствие Ksenks как отдельного спикера при явном упоминании участия.
+
+# Задачи на ручную проверку
+manual_review_tasks:
+  - task: "voice_comparison"
+    speakers: ["SPEAKER_MISATTRIBUTED_ELDAR"]
+    audio_url: null  # Нужно получить из desc.json оригинального data/
+    description: "Определить реального автора 7 реплик, ошибочно приписанных Эльдару"
+
+  - task: "voice_comparison"
+    speakers: ["SPEAKER_MISATTRIBUTED_LAVALE"]
+    description: "Определить реального автора 4 реплик, ошибочно приписанных Lavale"
+
+  - task: "contextual_review"
+    speakers: ["SPEAKER_05"]
+    description: "Проверить контекст коротких реплик и переатрибутировать"

--- a/validation/episodes/0300-0399/0375.yaml
+++ b/validation/episodes/0300-0399/0375.yaml
@@ -1,0 +1,287 @@
+episode: 375
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun]
+  guests_identified: [SPEAKER_00]
+  total_duration_sec: 7871  # ~2h 11m
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1897
+    replies_count: 318
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Критическая проблема: Marin_k_a - это НЕ Марина
+      # Umputun в начале говорит "Мы, короче, с Ксюшей на пару" (stime 17.1)
+      # Все обращения в эпизоде - "Ксюша", "Ксения" (найдено 17 упоминаний)
+      # Имя "Марина" НИ РАЗУ не упоминается в эпизоде
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "stime 17.1: 'Мы, короче, с Ксюшей на пару'; stime 564: 'Давай, Ксюша, ты привела мальчика'"
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 981
+    replies_count: 156
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Гость выпуска - Дмитрий, связанный с историей Winamp
+      # Живёт на Гавайях, раньше жил в Черноголовке (научный городок)
+      # Umputun явно представляет его: "Это Дмитрий" (stime 505.38)
+      identified_as: null  # Нужно найти ID в справочнике или создать
+      identification_method: "introduction"
+      confidence: high
+      evidence: "stime 505.38: 'Это Дмитрий'; stime 506.72: 'Дмитрий, ты попал в радиотип'; stime 525.57: 'Ближе к солнцу это Гавайи'; stime 611.72: 'из поселка Черноголовка'"
+
+      possible_matches:
+        - person_id: "dmitriy_winamp"
+          confidence: 0.95
+          reason: "Гость, связанный с Winamp, живёт на Гавайях, из Черноголовки"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 595.09
+          etime: 610.22
+          text: "Я случайно оказался как бы в середине этой всей истории, и никто, конечно, не ожидал таких больших результатов, что произойдет с миром, с музыкой, с музыкальным миром."
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 863
+    replies_count: 351
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # SPEAKER_02 появляется с 47 сек, когда по словам Umputun там только он и Ксюша
+      # Реплики часто дублируют/продолжают мысли Marin_k_a
+      # Скорее всего это тот же Ksenks с ошибкой распознавания голоса
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: "stime 47.44: 'Наглые' (когда в эфире только Umputun и Ксюша); stime 194.85: дублирует фразу Umputun"
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.75
+          reason: "В начале эпизода только Umputun и Ксюша; реплики чередуются с Marin_k_a"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 116.64
+          etime: 121.78
+          text: "Шуба-то шуба, и оступаешь-то все равно по промерзлой земле."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 28
+    replies_count: 6
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Реплики разбросаны по эпизоду, содержательные
+      # Одна из реплик упоминает Дмитрия: "вопросы будут к Дмитрию"
+      # Вероятно это Ksenks (реплики про программирование, TCL)
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: "stime 583.95: 'Может быть, из чата еще вопросы будут к Дмитрию'; stime 8297.46: вопрос про TCL"
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.70
+          reason: "Контекст указывает на ведущую, знающую гостя"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 8297.46
+          etime: 8304.5
+          text: "Вот, например, где бы ты посоветовал людям прочитать про TCL, про который мы сегодня говорили 25 лет?"
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 10
+    replies_count: 8
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие односложные реплики, разбросанные по эпизоду. Типичные ошибки распознавания."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Примеры: 'Бобука, да нет.', 'Какой?', 'Да.', 'В том же самом дропбоксе.' - всё менее 5 сек"
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 7
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Женский род в речи ('я не понимала') указывает что это не Пётр. Вероятно ошибка распознавания Ksenks."
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: "stime 3887.49: 'Я не понимала, что это значит, когда ТЫ рассказываЛА' - женский род обоих участников"
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.80
+          reason: "Женский род в речи"
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Единственная реплика 'Давай' в 2071 сек - типичная ошибка распознавания"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "stime 2071.15: 'Давай.' - 2 сек, односложная реакция"
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "Gray"
+    total_duration_sec: 3
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Gray не упоминается в выпуске, единственная реплика 'Как-то выживают' (stime 108.9) скорее всего принадлежит Ksenks или SPEAKER_02"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Umputun говорит 'Пока нас два' и перечисляет только себя и Ксюшу. Gray не представлен."
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.60
+          reason: "В этот момент в эфире только Umputun и Ксюша"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 108.9
+          etime: 111.5
+          text: "Как-то выживают."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Marin_k_a"
+      issue: "КРИТИЧНО: Атрибутировано как Марина, но все обращения в эпизоде - 'Ксюша/Ксения'. Должен быть Ksenks."
+
+    - speaker: "SPEAKER_02"
+      issue: "351 реплика без идентификации. Вероятно тот же Ksenks (фрагментация голоса)."
+
+    - speaker: "Gray"
+      issue: "Указан как присутствующий (1 реплика), но не представлен и не упоминается. Вероятно ошибка."
+
+    - speaker: "SPEAKER_00"
+      issue: "Идентифицирован как Дмитрий (гость про Winamp), но ID не найден в people.yaml"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 375
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Umputun говорит 'мы с Ксюшей на пару', все 17 обращений в эпизоде - Ксюша/Ксения, имя Марина не упоминается ни разу"
+
+  - type: rename
+    episode: 375
+    from_speaker: "SPEAKER_00"
+    to_speaker: "DmitriyWinamp"
+    confidence: high
+    reason: "Явное представление: 'Это Дмитрий', 'Дмитрий, ты попал в радиотип'. Гость связан с историей Winamp."
+
+  - type: rename
+    episode: 375
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: "Появляется когда в эфире только Umputun и Ксюша. Требуется voice comparison для подтверждения."
+
+  - type: rename
+    episode: 375
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: "Реплики указывают на ведущую. Требуется voice comparison."
+
+  - type: rename
+    episode: 375
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: "Женский род в речи ('я не понимала') - точно не Пётр"
+
+  - type: delete
+    episode: 375
+    from_speaker: "SPEAKER_01"
+    to_speaker: null
+    confidence: medium
+    reason: "Артефакты распознавания - короткие односложные реплики"
+
+  - type: delete
+    episode: 375
+    from_speaker: "SPEAKER_03"
+    to_speaker: null
+    confidence: medium
+    reason: "Артефакт - единственная реплика 'Давай'"
+
+  - type: rename
+    episode: 375
+    from_speaker: "Gray"
+    to_speaker: "Ksenks"
+    confidence: low
+    reason: "Gray не представлен, в этот момент в эфире только Umputun и Ксюша. Требуется voice comparison."
+
+# Задача для справочника people.yaml
+people_yaml_updates:
+  - action: add_guest
+    id: "dmitriy_winamp"
+    canonical_name: "DmitriyWinamp"
+    aliases: ["Дмитрий"]
+    real_name: "Дмитрий"
+    info: "Разработчик, связан с историей Winamp. Живёт на Гавайях, из Черноголовки. Выпуск 375."

--- a/validation/episodes/0300-0399/0376.yaml
+++ b/validation/episodes/0300-0399/0376.yaml
@@ -1,0 +1,166 @@
+episode: 376
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  # Ksenks присутствует но атрибутирована как SPEAKER_00
+  total_duration_sec: ~7500  # ~2 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 450
+    replies_count: 91
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "registry"
+      confidence: high
+      evidence: "Marin_k_a уже зарегистрирована в people.yaml как бывшая ведущая Марина"
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 352
+    replies_count: 157
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      # Очень высокая уверенность: контекст показывает что это Ksenks
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. В начале выпуска (50s) Umputun говорит "Ксюша больше меня пропускала"
+        2. SPEAKER_00 сразу отвечает (54s): "Хотя она... Нет, такого просто не может быть" — о себе
+        3. SPEAKER_00 спорит о сроках своего присоединения (59s): "Какой 6?", "Меньше"
+        4. Реплики SPEAKER_00 используют женский род: "я забыла" (3365s)
+        5. К SPEAKER_00 обращаются как к "Ксюша" (279s, 500s, 709s и др.)
+        6. Ksenks вообще отсутствует как спикер в файле (0 реплик)
+
+      voice_task:
+        needed: true
+        reason: "Подтвердить идентификацию голосовым сравнением"
+        reference_segment:
+          stime: 3362.79
+          etime: 3375.42
+          text: "И на iOS я часто пользуюсь поиском. Как раз если я забыла какое-то тестовое приложение, помню только название, оно у меня в папочке «тест», но там много этих приложений, искать неудобно."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 15
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Эти реплики помечены как SPEAKER_MISATTRIBUTED_LAVALE — это означает,
+        что ранее они были ошибочно атрибутированы как Lavale, но потом
+        атрибуция была отменена. Судя по контексту (2245s, 4686s) и содержанию,
+        эти реплики принадлежат кому-то из присутствующих женщин-ведущих
+        (Ksenks или Marin_k_a).
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "Контекст показывает женский голос, рядом реплики SPEAKER_00"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Marin_k_a тоже участвует в этом выпуске"
+
+      voice_task:
+        needed: true
+        reason: "Определить кому принадлежат эти реплики"
+        reference_segment:
+          stime: 2245.36
+          etime: 2255.14
+          text: "Я вот недавно свежий обладатель буквально, однодневный практически, но у макбука просто с ретиной, и прям вообще не закат, по-моему."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 6
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Эти реплики помечены как SPEAKER_MISATTRIBUTED_ELDAR — ранее были
+        ошибочно атрибутированы как Eldar (Эльдар Муртазин), но Эльдар
+        не участвует в этом выпуске. Короткие реплики (6463s, 7318s),
+        вероятно ошибки распознавания.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Короткие поддакивания, рядом реплики SPEAKER_00"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Может быть ошибка распознавания Bobuk"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Может быть ошибка распознавания Gray"
+
+      voice_task:
+        needed: false
+        reason: "Слишком короткие реплики для voice comparison"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_00"
+      issue: |
+        157 реплик атрибутированы как SPEAKER_00, хотя это явно Ksenks.
+        Ksenks участвует в разговоре, к ней обращаются по имени,
+        но ни одна реплика не атрибутирована как Ksenks.
+    - speaker: "Umputun"
+      issue: |
+        Реплика на 63.59s содержит текст с женским родом: "Ну и вообще я была слушателем".
+        Это вероятно слова Ksenks, ошибочно атрибутированные Umputun.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 376
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      SPEAKER_00 = Ksenks: контекст разговора о пропусках, обращения по имени "Ксюша",
+      женский род в речи ("я забыла"), полное отсутствие Ksenks среди спикеров
+
+  - type: rename
+    episode: 376
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      Вероятно принадлежит Ksenks — рядом реплики SPEAKER_00, женский контекст.
+      Требует voice comparison для подтверждения.
+
+  - type: single_fix
+    episode: 376
+    stime: 63.59
+    from_speaker: "Umputun"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      Текст "Ну и вообще я была слушателем" — женский род,
+      это явно слова Ksenks о своём прошлом как слушателя подкаста.
+
+# Примечания
+notes: |
+  Выпуск 376 от 25 января 2014 года.
+  Участники: Umputun, Bobuk, Gray, Ksenks (как SPEAKER_00), Marin_k_a.
+
+  Основная проблема: Ksenks полностью атрибутирована как SPEAKER_00 (157 реплик).
+  Это требует массового переименования после подтверждения через voice comparison.
+
+  SPEAKER_MISATTRIBUTED_* — это следы предыдущих ошибочных исправлений,
+  которые были откачены. Нужно определить реального спикера.

--- a/validation/episodes/0300-0399/0377.yaml
+++ b/validation/episodes/0300-0399/0377.yaml
@@ -1,0 +1,329 @@
+episode: 377
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Bobuk, Gray]
+  guests_present: [Ksenks, Marin_k_a]
+  total_duration_sec: 7660
+  note: "Umputun отсутствует (упоминается как 'Женя' в отъезде)"
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 1151
+    replies_count: 343
+    pattern: consecutive
+    first_appearance_sec: 8.3
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. Bobuk обращается: "Ксюша, ты у нас начнешь сегодня?" (194s)
+        2. Женский род: "Я думала" (159s), "я не сказала" (1731s), "я сама разберусь" (6506s)
+        3. Активно участвует с самого начала подкаста (8s)
+        4. Ведёт диалог с Marin_k_a как отдельный человек
+
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 587
+    replies_count: 100
+    pattern: consecutive
+    first_appearance_sec: 420.9
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Уже корректно размечена в транскрипте как Marin_k_a (Марина).
+        Активно участвует в диалогах с SPEAKER_02 (Ksenks) как отдельный человек.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 87
+    replies_count: 35
+    pattern: scattered
+    first_appearance_sec: 204.0
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Ошибка распознавания голоса. Реплики разбросаны по всему эпизоду.
+        Говорит в женском роде ("Я думала, я гик" 6842s, "я тоже подумала" 6970s).
+        Переключается быстро и с SPEAKER_02, и с Marin_k_a.
+        Скорее всего это Ksenks с ошибкой атрибуции голоса.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: "Женский род, быстрые переключения с SPEAKER_02"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Также женский род, но менее вероятно"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6890.2
+          etime: 6900.8
+          text: "Мне кажется, это странно, когда получается, что все руки, глаза и все остальное..."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 19
+    replies_count: 2
+    pattern: scattered
+    first_appearance_sec: 2570.3
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Маркер отменённой ошибочной атрибуции. Lavale не участвовала в этом выпуске.
+        Реплики скорее всего принадлежат одной из женщин (Ksenks или Marin_k_a).
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "Контекст про видео и технологии"
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "Также возможно"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2570.3
+          etime: 2579.3
+          text: "Не, видео, мне кажется, посмотреть стоит, потому что оно, как часто бывает, очень красиво сделано"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 7
+    replies_count: 3
+    pattern: scattered
+    first_appearance_sec: 1262.2
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Маркер отменённой ошибочной атрибуции. Эльдар Муртазин не участвовал в этом выпуске.
+        Короткие реплики ("Расскажешь?", "Нет, понимаешь, там в чем дело"),
+        скорее всего принадлежат одному из ведущих или гостей.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Короткие реплики, стиль ведущего"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Также возможно"
+        - person_id: "ksenks"
+          confidence: 0.2
+          reason: "Если женский голос"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+        reason: "Слишком короткие реплики (< 5 сек) для voice comparison"
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 6
+    replies_count: 4
+    pattern: scattered
+    first_appearance_sec: 1851.4
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие разрозненные реплики: "Не, он немножко похож", "Он, конечно, менее волосат",
+        "Нет, нет, нет", "Ну, да". Типичные ошибки распознавания.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Короткие реплики в контексте обсуждения"
+        - person_id: "gray"
+          confidence: 0.4
+          reason: "Также возможно"
+        - person_id: "ksenks"
+          confidence: 0.2
+          reason: "Менее вероятно"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+        reason: "Слишком короткие реплики для voice comparison"
+
+  - speaker: "SPEAKER_07"
+    total_duration_sec: 4
+    replies_count: 4
+    pattern: scattered
+    first_appearance_sec: 35.6
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Очень короткие разрозненные реплики: "В кусты" (35s), "Нижняя на S4 физическая кнопка" (968s),
+        "Ну да" (3788s), "Сюжет" (5940s). Типичные ошибки распознавания.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Реплики в контексте диалога"
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Также возможно"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+        reason: "Слишком короткие реплики для voice comparison"
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 4
+    replies_count: 1
+    pattern: scattered
+    first_appearance_sec: 4284.8
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одна реплика: "Почему оно вообще хуже-то?" (4284s).
+        Явная ошибка распознавания.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Контекст обсуждения"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Также возможно"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Короткий вопрос"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+        reason: "Одна короткая реплика"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "SPEAKER_02"
+      issue: |
+        Основной спикер с 343 репликами размечен как SPEAKER_02, но это Ksenks.
+        Ксюша представлена в начале выпуска: "Ксюша, ты у нас начнешь сегодня?" (194s)
+    - speaker: "SPEAKER_00"
+      issue: |
+        35 реплик разбросаны по выпуску. Женский род указывает на Ksenks или Marina.
+        Требуется voice comparison для точной идентификации.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 377
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      1. Bobuk обращается к SPEAKER_02: "Ксюша, ты у нас начнешь сегодня?"
+      2. Женский род в речи: "Я думала", "я сама разберусь", "я не сказала"
+      3. Активно участвует с начала выпуска (8s)
+      4. Ведёт самостоятельные диалоги с Marin_k_a как отдельный человек
+
+  - type: review_needed
+    episode: 377
+    from_speaker: "SPEAKER_00"
+    candidates: ["Ksenks", "Marin_k_a"]
+    confidence: medium
+    reason: |
+      Женский род, но непонятно кто именно.
+      Требуется voice comparison с Ksenks и Marina.
+
+  - type: delete_or_merge
+    episode: 377
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    candidates: ["Ksenks", "Marin_k_a"]
+    confidence: medium
+    reason: "Lavale не участвовала. Реплики принадлежат одной из женщин."
+
+  - type: delete_or_merge
+    episode: 377
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    candidates: ["Bobuk", "Gray", "Ksenks"]
+    confidence: medium
+    reason: "Эльдар Муртазин не участвовал. Короткие реплики от ведущих."
+
+  - type: delete_or_merge
+    episode: 377
+    from_speaker: "SPEAKER_01"
+    candidates: ["Bobuk", "Gray"]
+    confidence: low
+    reason: "Короткие разрозненные реплики, скорее всего ошибки распознавания"
+
+  - type: delete_or_merge
+    episode: 377
+    from_speaker: "SPEAKER_07"
+    candidates: ["Bobuk", "Gray"]
+    confidence: low
+    reason: "Короткие разрозненные реплики, скорее всего ошибки распознавания"
+
+  - type: delete_or_merge
+    episode: 377
+    from_speaker: "SPEAKER_05"
+    candidates: ["Ksenks", "Marin_k_a", "Bobuk"]
+    confidence: low
+    reason: "Одна короткая реплика, скорее всего ошибка распознавания"
+
+# Аудио для voice comparison
+audio_reference:
+  url: null  # Файл 377_desc.json отсутствует
+  note: "Метаданные эпизода не найдены. URL аудио недоступен."

--- a/validation/episodes/0300-0399/0378.yaml
+++ b/validation/episodes/0300-0399/0378.yaml
@@ -1,0 +1,225 @@
+episode: 378
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray, Bobuk]
+  guests_present: [Marin_k_a]  # Марина - бывшая ведущая
+  total_duration_sec: 7800  # ~2 часа 10 минут
+
+# Контекст из начала эпизода
+episode_context:
+  intro_notes: |
+    Umputun: "Бобук с нами пока отсутствует, все остальные зато тут"
+    Umputun спрашивает "Ксюша, ты из места постоянного базирования?" - SPEAKER_01 отвечает.
+    Bobuk появляется позже (~343s).
+    Marin_k_a участвует активно наравне с ведущими.
+  participants_mentioned:
+    - Umputun (ведущий, из США)
+    - Gray (из домашней студии, Киев упоминается)
+    - Ksenks (место постоянного базирования = Финляндия)
+    - Bobuk (присоединяется позже)
+    - Marin_k_a (активный участник - Марина, бывшая ведущая)
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 991
+    replies_count: 360
+    first_appearance_sec: 57
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Umputun спрашивает "Ксюша, ты из места постоянного базирования?" (54-57s),
+        SPEAKER_01 отвечает "Да, из места постоянного базирования." (57s).
+        Упоминание Финляндии в контексте биатлона также связано с Ksenks.
+        Активное участие на протяжении всего выпуска (360 реплик).
+
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1189
+    replies_count: 185
+    first_appearance_sec: 84
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Уже идентифицирована в people.yaml как Марина (бывшая ведущая).
+        Активное участие в дискуссиях, женский голос (видно по грамматике: "мне кажется", "я знаю").
+        Длительные содержательные реплики о технологиях.
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 98
+    replies_count: 41
+    first_appearance_sec: 157
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие разрозненные реплики (в среднем 2.4 сек каждая).
+        Появляются между репликами основных спикеров.
+        Примеры: "То есть как бы нужно понять еще какие" (157s),
+        "Все, пока ты тудуист" (654s), "Да" (2084s), "То есть это был баг?" (2086s).
+        Вероятно это ошибки распознавания голосов Ksenks или Marin_k_a,
+        либо перекрывающаяся речь.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "Многие реплики вписываются в контекст диалога с Ksenks"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Некоторые реплики могут быть Мариной"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2079.72
+          etime: 2086.56
+          text: "У меня с того... На телевизоре? / Да / То есть это был баг? / Все."
+          note: "Серия коротких реплик, нужно сравнить с голосами Ksenks и Marin_k_a"
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 2
+    replies_count: 1
+    first_appearance_sec: 796
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика "Это всякое бывает" (796s) между репликами Gray.
+        Скорее всего ошибка сегментации - это продолжение речи Gray или
+        короткая реакция одного из участников.
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Реплика между двумя репликами Gray, может быть его же речь"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Короткая реакция участника диалога"
+
+      voice_task:
+        needed: false
+        reason: "Слишком короткий сегмент (2 сек) для voice comparison"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 5
+    replies_count: 3
+    first_appearance_sec: 1090
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Помечено как MISATTRIBUTED - ранее ошибочно присвоено Lavale.
+        Короткие фразы между репликами Marin_k_a и Gray:
+        - "С одной стороны, ты прав." (1090s)
+        - "У них виндовые компьютеры." (1123s)
+        - "То есть у меня не последний андроид, как видно." (2121s)
+        Все реплики вписываются в контекст речи Marin_k_a.
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.8
+          reason: "Реплики идут в контексте речи Marin_k_a, тематически связаны"
+        - person_id: "ksenks"
+          confidence: 0.2
+          reason: "Альтернативный вариант"
+
+      voice_task:
+        needed: false
+        reason: "Слишком короткие сегменты, контекст указывает на Marin_k_a"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 8
+    replies_count: 3
+    first_appearance_sec: 5313
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Помечено как MISATTRIBUTED - ранее ошибочно присвоено Эльдару Муртазину.
+        Короткие фразы в разных частях выпуска:
+        - "Там просто есть... У него законопроекты все еще нет?" (5313s)
+        - "Система продажи игр." (6831s)
+        - "Совершенно нечего." (7668s)
+        Эльдар Муртазин не был гостем этого выпуска.
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Активный участник диалога, короткие реакции характерны"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Возможно реплики Gray"
+        - person_id: "marin_k_a"
+          confidence: 0.2
+          reason: "Альтернативный вариант"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5312.66
+          etime: 5317.62
+          text: "Там просто есть... У него законопроекты все еще нет?"
+          note: "Самый длинный сегмент MISATTRIBUTED_ELDAR, нужно определить спикера"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Ksenks"
+      issue: "Не представлена явно, но идентифицируется по обращению 'Ксюша' и вопросу про Финляндию"
+    - speaker: "Marin_k_a"
+      issue: "Не представлена явно в начале, но активно участвует с ~84 секунды"
+    - speaker: "Bobuk"
+      issue: "Присоединяется позже (~343s), что объясняется в начале выпуска"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 378
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun обращается к Ксюше (54s), SPEAKER_01 отвечает.
+      360 реплик, 991 сек - активный участник на протяжении всего выпуска.
+      Контекст разговора про Финляндию подтверждает идентификацию.
+
+  - type: rename
+    episode: 378
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Marin_k_a"
+    confidence: medium
+    reason: |
+      Короткие реплики в контексте речи Marin_k_a.
+      Тематически связаны с окружающими репликами Марины.
+      Lavale не была гостем этого выпуска.
+
+# Дополнительные наблюдения
+notes: |
+  1. Выпуск 378 (февраль 2014) - обсуждение Олимпиады в Сочи, биатлона.
+  2. Марина (Marin_k_a) - активный участник, бывшая ведущая, уже в справочнике.
+  3. SPEAKER_00 требует дополнительного анализа - много коротких реплик.
+  4. SPEAKER_MISATTRIBUTED_* уже помечены как ошибки в предыдущих чистках.
+  5. Bobuk мало говорит (6 реплик, 23 сек) - возможно были технические проблемы.

--- a/validation/episodes/0300-0399/0379.yaml
+++ b/validation/episodes/0300-0399/0379.yaml
@@ -1,0 +1,155 @@
+episode: 379
+status: clean
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7320  # ~2 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1289
+    replies_count: 352
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "В начале выпуска (15s) Umputun говорит 'Ксюша опоздала на 15 минут', а Marin_k_a отвечает (21s) 'Я проспала'. Марина - бывшая ведущая, известная участница подкаста."
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 13
+    replies_count: 7
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие разрозненные реплики (7 штук за 2 часа) в разных частях выпуска. Это ошибки распознавания одного из ведущих. Реплики по контексту принадлежат разным спикерам: 'Как ты мог проснуться от срача в Твиттере?' (551s) - вопрос к Umputun, вероятно Marin_k_a или Gray; 'Ну все, моя миссия выполнена' (7179s) - контекст после реплики Bobuk."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Некоторые реплики по контексту похожи на женский голос (вопросы про Twitter)"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Часть реплик может быть Gray (короткие комментарии)"
+
+      voice_task:
+        needed: false
+        # Слишком короткие сегменты для voice comparison (1-3 сек каждый)
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 10
+    replies_count: 4
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Это отменённые ошибочные присвоения Эльдару Муртазину, который НЕ участвовал в выпуске 379. Реплики короткие и разбросаны. По контексту это скорее всего ошибки распознавания ведущих: 'А что, не пустите?' (1263s) - после Marin_k_a про 'Почините', 'Я только дочки свои поставил' (2941s) - мужской голос в контексте обсуждения."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Некоторые реплики по интонации и контексту могут быть Bobuk"
+        - person_id: "gray"
+          confidence: 0.4
+          reason: "Часть реплик может быть Gray"
+
+      voice_task:
+        needed: false
+        # Слишком короткие сегменты (1-4 сек)
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 8
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Отменённые ошибочные присвоения Lavale, которая НЕ участвовала в выпуске 379. Все 3 реплики короткие и разбросаны: 'Хотя бы как обычные птички' (701s), 'В десятых числах марта' (5562s), 'Это же просто вообще, я не знаю' (6572s). Контекст показывает продолжение мысли Marin_k_a."
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: medium
+      evidence: "Все 3 реплики идут сразу после реплик Marin_k_a и продолжают её мысль. Вероятно это ошибки сегментации - части речи Марины, ошибочно выделенные в отдельные сегменты."
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 4
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Очень короткие реплики (по 1-2 сек) в разных частях выпуска: 'И регионы с английского' (1462s), 'Вообще да' (6210s), 'И на митингах' (6581s). Это ошибки распознавания - короткие вставки или перебивки."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "Реплика 'И регионы с английского' (1462s) идёт в контексте речи Marin_k_a о Хабре"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "'Вообще да' (6210s) - после вопроса Umputun, перед ответом Bobuk"
+
+      voice_task:
+        needed: false
+        # Слишком короткие сегменты (1-2 сек)
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes: "В начале выпуска (2-20s) Umputun представляет состав: он сам (болеет), Ксюша (опоздала - это Marin_k_a), Bobuk, Gray. Все основные спикеры озвучены."
+  issues: []
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 379
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Marin_k_a"
+    confidence: medium
+    reason: "Все 3 реплики по контексту продолжают мысль Marin_k_a и являются ошибками сегментации"
+
+# Примечания
+notes: |
+  Выпуск 379 от 15 февраля 2014 года.
+  Состав: Umputun (болеет), Bobuk, Gray, Marin_k_a (Марина/Ксюша - бывшая ведущая).
+
+  Marin_k_a уже правильно идентифицирована в транскрипте - это Марина,
+  бывшая ведущая подкаста. В начале её называют "Ксюша", что является
+  дружеским прозвищем или ошибкой в транскрипте.
+
+  Все неизвестные спикеры (SPEAKER_00, SPEAKER_02, SPEAKER_MISATTRIBUTED_*)
+  являются ошибками распознавания - короткие фрагменты (1-4 сек),
+  разбросанные по выпуску. Не требуют voice comparison из-за малой
+  длительности сегментов.

--- a/validation/episodes/0300-0399/0380.yaml
+++ b/validation/episodes/0300-0399/0380.yaml
@@ -1,0 +1,176 @@
+episode: 380
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7300  # ~2 часа, примерная оценка
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 589
+    replies_count: 220
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: "Umputun спрашивает 'Ксюшу' в начале (9.5s), SPEAKER_00 отвечает (22.9s). Множество обращений к Ксюше в течение выпуска, SPEAKER_00 участвует в диалогах как полноценный ведущий. 220 реплик - типичный объём для ведущего."
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 738
+    replies_count: 124
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "registry"
+      confidence: high
+      evidence: "Marin_k_a уже присутствует в people.yaml как Марина (бывшая ведущая). Первая реплика (77s): 'Мы будем сегодня с Бабуком читать стихи' - участвует в шутливом диалоге с ведущими как свой человек."
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 3
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Две короткие реплики (1.2 сек и 2.3 сек) в разных частях выпуска (1369s и 4126s). Типичные ошибки автоматического распознавания - короткие фразы, вклинившиеся в диалог ведущих."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.4
+          reason: "Первая реплика (1369s) 'Зачем ты это хочешь?' следует за репликой Umputun, возможно продолжение его речи"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Вторая реплика (4126s) 'Какому-то Яндеху' - ироничный комментарий, может быть Gray"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+        reason: "Слишком короткие сегменты для voice comparison"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 13
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Реплика (4386s, 13 сек): 'А, нет, позволяет, нет, ну, в смысле провиженинг телефонов через, там, эпловые провиженинг профайлы...' - техническая речь про MDM. Следует за репликой Gray про mobile device management."
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Техническая тема (MDM, provisioning), продолжение мысли Gray"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Bobuk часто обсуждает корпоративные IT-решения"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 4386.12
+          etime: 4399.15
+          text: "А, нет, позволяет, нет, ну, в смысле провиженинг телефонов через, там, эпловые провиженинг профайлы и так далее, установку, это позволяет, конечно, да."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 6
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Две короткие реплики в разных частях выпуска. Первая (6165s): 'Может быть, у Бобука есть что по этому поводу сказать?' - обращение к Bobuk, типичная фраза ведущего. Вторая (7260s): 'Это как-то очень странно' - короткий комментарий."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Первая реплика следует за репликой Marin_k_a (6161s). Возможно продолжение её речи, неправильно разделённое."
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Манера обращения к Bobuk характерна для Ksenks"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6165.72
+          etime: 6169.31
+          text: "Может быть, у Бобука есть что по этому поводу сказать?"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_00"
+      issue: "220 реплик от неидентифицированного спикера. По контексту это Ksenks, рекомендуется переименовать."
+    - speaker: "SPEAKER_04"
+      issue: "2 короткие реплики - ошибки распознавания. Рекомендуется присвоить ближайшему ведущему или удалить."
+    - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+      issue: "Название предполагает отменённое присвоение Петру Диденко. Нужна ручная проверка голоса."
+    - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+      issue: "Название предполагает отменённое присвоение Лавале. Скорее всего ошибка распознавания, реплики принадлежат другому ведущему."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 380
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Контекстуальный анализ: Umputun обращается к 'Ксюше', SPEAKER_00 отвечает. 220 реплик, 589 сек - полноценное участие ведущего."
+
+  - type: merge_with_context
+    episode: 380
+    from_speaker: "SPEAKER_04"
+    confidence: medium
+    reason: "2 короткие ошибочные реплики. Нужна ручная проверка контекста для определения, кому они принадлежат."
+
+  - type: voice_verification_needed
+    episode: 380
+    speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    confidence: medium
+    reason: "Одна реплика 13 сек с технической речью. Требуется voice comparison для определения спикера."
+
+  - type: merge_with_context
+    episode: 380
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    confidence: medium
+    reason: "2 короткие реплики, скорее всего принадлежат Marin_k_a или Ksenks. Первая реплика следует за Marin_k_a."

--- a/validation/episodes/0300-0399/0381.yaml
+++ b/validation/episodes/0300-0399/0381.yaml
@@ -1,0 +1,306 @@
+episode: 381
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 8222
+  notes: |
+    Выпуск от 1 марта 2014 года. В начале Umputun говорит: "Сегодня вместо выбывшего Грея...
+    пришла целая команда подкаста «Разбор полетов»". Gray присоединяется только с 4287 секунды (71 мин).
+    В эпизоде участвует Ksenks (Ксюша), но она ошибочно размечена как SPEAKER_07.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 1047
+    replies_count: 194
+    first_appearance_sec: 36
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "alexey_abashev"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. В начале эпизода (39s) Umputun говорит: "Да-да, это коллеги из подкаста «Разбор полетов»"
+        2. В 2749.7s Umputun обращается: "Понимаешь, у них концептуально есть такая... вещь, Леш..."
+           Перед этим говорил SPEAKER_00.
+        3. В 1342.9s Marin_k_a говорит: "Ну там же Леша просто сказал"
+           В 1344.5s SPEAKER_00 подтверждает: "Да, Леша"
+        4. Подкаст "Разбор полетов" ведут Алексей Абашев и Виктор Гамов (Java-разработчики).
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 872
+    replies_count: 228
+    first_appearance_sec: 29
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "viktor_gamov"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. Второй ведущий подкаста "Разбор полетов" (Виктор Гамов).
+        2. В начале (42.2s) говорит: "Он ни разу не сказал «Разбор полетов» за все время,
+           пока мы тут общаемся" — типичная шутка соведущего.
+        3. Говорит о Java-темах (TypeScript, JavaScript компиляция в 4278-4314s).
+        4. Объем реплик сопоставим со SPEAKER_00 — оба активные участники.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_07"
+    total_duration_sec: 369
+    replies_count: 127
+    first_appearance_sec: 102
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. В 993.9s Umputun говорит: "Ксюша, у меня к тебе вопрос" → в 1000.7s SPEAKER_07 отвечает
+        2. В 1718.4s Umputun: "Ксюша, знаешь ли ты такую науку-комбинаторику?" →
+           в 1723.2s SPEAKER_07: "Да, слышала, чуток"
+        3. В 1739.1s SPEAKER_07: "Не, ну так и так, в принципе, понятно" — продолжает разговор
+        4. Обращения к "Ксюше" последовательно получают ответы от SPEAKER_07.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 525
+    replies_count: 81
+    first_appearance_sec: 140
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Уже корректно идентифицирована в справочнике people.yaml как бывшая ведущая Марина.
+        Участвует в технических обсуждениях (монады, функциональное программирование).
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_06"
+    total_duration_sec: 37
+    replies_count: 18
+    first_appearance_sec: 54
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие разрозненные реплики (37 сек на 18 реплик = ~2 сек в среднем).
+        Типичные фразы: "Ну да, может быть 10", "Берите", "А что?".
+        Вероятно ошибки распознавания одного из присутствующих спикеров.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Может быть ошибка распознавания Ксюши"
+        - person_id: "alexey_abashev"
+          confidence: 0.3
+          reason: "Или одного из гостей из Разбор полетов"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5024.8
+          etime: 5029.5
+          text: "Да, но быстро закончится это парное программирование, ты останешься один."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 26
+    replies_count: 6
+    first_appearance_sec: 380
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Название указывает на ошибочную атрибуцию к Эльдару Муртазину.
+        6 коротких реплик, разбросанных по эпизоду.
+        Реплики по содержанию относятся к Java-разработке ("саджавийские чуваки", "BlueSync").
+        Скорее всего ошибки распознавания SPEAKER_00 или SPEAKER_04.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "alexey_abashev"
+          confidence: 0.5
+          reason: "Java-тематика реплик, соответствует профилю"
+        - person_id: "viktor_gamov"
+          confidence: 0.5
+          reason: "Также Java-разработчик"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 10
+    replies_count: 5
+    first_appearance_sec: 1187
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        5 очень коротких реплик (всего 10 секунд).
+        Типичные фразы: "Да", "Шампанского", "Очень интересно, расскажи".
+        Ошибки распознавания.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Короткие одобрительные реплики"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_08"
+    total_duration_sec: 1
+    replies_count: 1
+    first_appearance_sec: 7256
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика в 1 секунду: "Есть такое, да."
+        Очевидная ошибка распознавания.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Gray"
+    total_duration_sec: 56
+    replies_count: 6
+    first_appearance_sec: 4287
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "gray"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Gray появляется только с 4287 секунды (71 минута эпизода).
+        В начале (12s) Umputun говорит: "Сегодня вместо выбывшего Грея... по понятным причинам".
+        Вероятно Gray присоединился к трансляции позже.
+        Содержание реплик техническое, соответствует стилю Gray.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_07"
+      issue: "Ksenks (Ксюша) участвует в эпизоде, но размечена как SPEAKER_07. Нужно переименовать."
+    - speaker: "SPEAKER_00"
+      issue: "Алексей Абашев из 'Разбор полетов' не представлен по имени, но идентифицирован через обращение 'Леша'"
+    - speaker: "SPEAKER_04"
+      issue: "Виктор Гамов из 'Разбор полетов' не представлен по имени напрямую"
+    - speaker: "Gray"
+      issue: "Появляется только с 4287s, хотя в начале сказано что он 'выбыл'"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 381
+    from_speaker: "SPEAKER_07"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Отвечает на прямые обращения к Ксюше в нескольких местах эпизода"
+
+  - type: rename
+    episode: 381
+    from_speaker: "SPEAKER_00"
+    to_speaker: "AlexeyAbashev"
+    confidence: high
+    reason: "Ведущий подкаста 'Разбор полетов', обращаются как 'Леша'"
+
+  - type: rename
+    episode: 381
+    from_speaker: "SPEAKER_04"
+    to_speaker: "ViktorGamov"
+    confidence: high
+    reason: "Второй ведущий подкаста 'Разбор полетов'"
+
+# Новые гости для добавления в people.yaml
+new_guests_for_registry:
+  - id: "alexey_abashev"
+    canonical_name: "AlexeyAbashev"
+    aliases: ["Алексей", "Леша", "Лёша", "Abashev"]
+    real_name: "Алексей Абашев"
+    info: "Ведущий подкаста 'Разбор полетов', Java-разработчик"
+
+  - id: "viktor_gamov"
+    canonical_name: "ViktorGamov"
+    aliases: ["Виктор", "Витя", "Gamov"]
+    real_name: "Виктор Гамов"
+    info: "Ведущий подкаста 'Разбор полетов', Java-разработчик"

--- a/validation/episodes/0300-0399/0382.yaml
+++ b/validation/episodes/0300-0399/0382.yaml
@@ -1,0 +1,272 @@
+episode: 382
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7200  # ~2 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 935
+    replies_count: 258
+    pattern: consecutive
+    first_appearance_sec: 49
+    analysis:
+      is_error: false
+      identified_as: "Vodom"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        На 46s Umputun говорит: "Водом, я тебя не обидел, что мы тебя не сильно звали?"
+        На 82s SPEAKER_01 говорит: "Ну, если вам интересна жизнь в Америке, то americhka.us. Это мой подкаст"
+        Уже идентифицирован в all_identified_guests.json
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 1168
+    replies_count: 306
+    pattern: consecutive
+    first_appearance_sec: 151
+    analysis:
+      is_error: false
+      identified_as: "Swan"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        На 123s Umputun говорит: "Самый большой скандал недели, и тут я не зря Свана позвал"
+        На 166s Umputun говорит: "Нет, Сван, давай вот пока мы к теме не перешли"
+        Сван - сисадмин, активно участвует в дискуссии о DevOps
+        Уже идентифицирован в all_identified_guests.json как "Сван (Владимир)"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 481
+    replies_count: 172
+    pattern: consecutive
+    first_appearance_sec: 19
+    analysis:
+      is_error: false
+      identified_as: "Ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        На 11-17s Umputun говорит: "В этом составчике вы не найдете ни Бобука, ни Грея... но найдете Ксюшу"
+        На 19s SPEAKER_04 отвечает: "Найдете меня"
+        На 335s Umputun обращается: "Ксюша, догадайся, что я им говорю" - затем SPEAKER_04 отвечает
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 639
+    replies_count: 119
+    pattern: consecutive
+    first_appearance_sec: 162
+    analysis:
+      is_error: false
+      identified_as: "Marin_k_a"
+      identification_method: "already_labeled"
+      confidence: high
+      evidence: "Уже размечена в транскрипте как Marin_k_a (Марина, бывшая ведущая)"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 404
+    replies_count: 91
+    pattern: consecutive
+    first_appearance_sec: 1491
+    analysis:
+      is_error: false
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Появляется на 1491s, когда Umputun говорит "Нет, ты прямо скажи, Умпутун несет чушь, а Сван красавец"
+        На 1495s SPEAKER_02 говорит: "Сван, ты тоже урод, как и я. Приятно быть в хорошей компании"
+        На 1581s: "Ну, я работал сам-то в Barclay..."
+        Это НЕ Водом (SPEAKER_01 продолжает говорить отдельно после 2005s)
+        Возможно это ошибка распознавания Водома или третий неанонсированный участник
+        В начале выпуска Umputun говорит о двух гостях (Водом и Сван), но SPEAKER_02 - отдельный голос
+      possible_matches:
+        - person_id: "Vodom"
+          confidence: 0.4
+          reason: "Возможно это тот же Водом, но ошибочно размеченный как SPEAKER_02"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1581.82
+          etime: 1609.64
+          text: "Ну, я работал сам-то в Barclay, не буду раскрывать слишком много деталей, понимаете, почему, но у них-то не один дата-центр, у них действительно, ну, на всех почти континентах свой дата-центр..."
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 5
+    replies_count: 1
+    pattern: scattered
+    first_appearance_sec: 4701
+    analysis:
+      is_error: true
+      error_reason: "Одна короткая изолированная реплика ('Мы болтики, мы болтики-отвертки') - скорее всего ошибка распознавания"
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 10
+    replies_count: 2
+    pattern: scattered
+    first_appearance_sec: 344
+    analysis:
+      is_error: true
+      error_reason: "Отменённое ошибочное присвоение - реплики ранее ошибочно приписаны PetrDidenko"
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        343.7s: "Зачем вам вообще даже один дата-центр?" - контекст после Umputun спрашивает "Ксюша, догадайся" и SPEAKER_04 отвечает
+        6329.5s: "Да, нужно закрывать хозяина контента..." - изолированная реплика
+        Требуется voice comparison для определения реального спикера
+      possible_matches:
+        - person_id: "Ksenks"
+          confidence: 0.5
+          reason: "Первая реплика идёт в контексте диалога с Ксюшей"
+        - person_id: "Vodom"
+          confidence: 0.3
+          reason: "Может быть Водом"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6329.51
+          etime: 6336.91
+          text: "Да, нужно закрывать хозяина контента, а не того, кто просто... Хозяин контента сидит где-то в Амазоне."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 4
+    replies_count: 2
+    pattern: scattered
+    first_appearance_sec: 1159
+    analysis:
+      is_error: true
+      error_reason: "Отменённое ошибочное присвоение - реплики ранее ошибочно приписаны EldarMurtazin (Эльдар не участвует в этом выпуске)"
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        1159.1s: "Он в два раза глупее тебя, ты считаешь?"
+        2865.5s: "Будешь читать через АПИ?"
+        Короткие реплики, требуют voice comparison
+      possible_matches:
+        - person_id: "Swan"
+          confidence: 0.4
+          reason: "Может быть Сван (SPEAKER_03)"
+        - person_id: "Vodom"
+          confidence: 0.3
+          reason: "Может быть Водом (SPEAKER_01)"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1159.13
+          etime: 1161.54
+          text: "Он в два раза глупее тебя, ты считаешь?"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 11
+    replies_count: 2
+    pattern: scattered
+    first_appearance_sec: 3776
+    analysis:
+      is_error: true
+      error_reason: "Отменённое ошибочное присвоение - реплики ранее ошибочно приписаны Lavale (Лаваль не участвует в этом выпуске)"
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        3775.6s: "Но мне кажется, что вообще логично, что в каждой команде нужно думать про архитектуру тоже"
+        4761.0s: "Помнишь, как вот Марко, по-моему, что-то продавал?"
+        Требуют voice comparison
+      possible_matches:
+        - person_id: "Marin_k_a"
+          confidence: 0.5
+          reason: "Может быть Марина - женский голос"
+        - person_id: "Ksenks"
+          confidence: 0.4
+          reason: "Может быть Ксюша - женский голос"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3775.64
+          etime: 3784.14
+          text: "Но мне кажется, что вообще логично, что в каждой команде нужно думать про архитектуру тоже."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_02"
+      issue: |
+        Umputun в начале анонсирует только двух гостей (Водом и Сван), но SPEAKER_02 появляется как третий
+        голос с 1491s и имеет 91 реплику (404 сек). Возможно это ошибка распознавания Водома,
+        но нужно voice comparison для подтверждения.
+    - speaker: "SPEAKER_MISATTRIBUTED_*"
+      issue: |
+        Три спикера с префиксом MISATTRIBUTED - это отменённые ошибочные присвоения.
+        Нужен voice comparison для корректной атрибуции.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 382
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Vodom"
+    confidence: high
+    reason: "Явное представление: подкаст americhka.us, обращение 'Водом'"
+
+  - type: rename
+    episode: 382
+    from_speaker: "SPEAKER_03"
+    to_speaker: "Swan"
+    confidence: high
+    reason: "Явное представление: 'тут я не зря Свана позвал', многократные обращения по имени"
+
+  - type: rename
+    episode: 382
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Явное представление: 'но найдете Ксюшу' -> 'Найдете меня', обращения 'Ксюша'"
+
+  - type: delete
+    episode: 382
+    speaker: "SPEAKER_05"
+    confidence: medium
+    reason: "Одна короткая изолированная реплика - ошибка распознавания"
+
+# Примечания
+notes: |
+  Эпизод 382 (8 марта 2014) - особый выпуск без Бобука и Грея.
+
+  Участники по данным начала выпуска:
+  - Umputun (ведущий)
+  - Ксюша (Ksenks) - "найдете Ксюшу"
+  - Водом - подкаст americhka.us
+  - Сван - сисадмин
+  - Марина (Marin_k_a) - не анонсирована, но присутствует
+
+  SPEAKER_02 требует дополнительного анализа - либо это ошибка распознавания Водома,
+  либо третий неанонсированный гость. Реплика о работе в Barclays уникальна.
+
+  Все SPEAKER_MISATTRIBUTED_* - это реплики, ранее ошибочно атрибутированные
+  участникам, которые НЕ участвуют в этом выпуске (Petr, Eldar, Lavale).

--- a/validation/episodes/0300-0399/0383.yaml
+++ b/validation/episodes/0300-0399/0383.yaml
@@ -1,0 +1,239 @@
+episode: 383
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  hosts_absent: [Gray, Alek.sys]
+  guests_identified: [Marin_k_a, EldarMurtazin]
+  guest_in_episode: "Александр Плющев (SPEAKER_04)"
+  total_duration_sec: 7894
+
+# Важное замечание в начале эпизода
+episode_context: |
+  Umputun (1-20s): "Сегодня все четыре человека пришло, но один из них вместо Грея.
+  И не просто вместо Грея. Он гость, который редкий, которого мы звали-звали.
+  И вот он пришел. Хотя, конечно, мы про тебя, Саша, немножко подзабыли."
+
+  В конце (7850-7854s): "В гостях Александр Плющев, небезызвестный вам."
+
+  Это подтверждает: Gray ОТСУТСТВУЕТ, гость - Александр Плющев.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 1405
+    replies_count: 360
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+
+      identified_as: "plushev"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. В начале: "Хотя, конечно, мы про тебя, Саша, немножко подзабыли" (17.93s)
+        2. В конце: "В гостях Александр Плющев, небезызвестный вам" (7850.89s)
+        3. Множественные обращения "Саша", "Александр", "Плющев" по тексту
+        4. Упоминание "Саша Плющева" (строка 13132)
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 487
+    replies_count: 189
+    pattern: scattered
+
+    analysis:
+      is_error: false
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        1. Umputun (63.63s): "Мы с Ксюшей тут каждую неделю сидим"
+        2. SPEAKER_00 отвечает на эту фразу: "Да, все записываем в тетрадочку" (66.81s)
+        3. Множественные обращения "Ксюша" по тексту направлены к этому спикеру
+        4. Паттерн коротких реплик характерен для Ksenks в других эпизодах
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.85
+          reason: "Контекст и обращения 'Ксюша'"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 417.18
+          etime: 431.72
+          text: "Что ты качал? Что, бобук? ... Да, лицензионного не было."
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 461
+    replies_count: 78
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "pre-labeled"
+      confidence: high
+      evidence: "Уже размечена в файле, известная участница подкаста"
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 290
+    replies_count: 50
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "eldar_murtazin"
+      identification_method: "pre-labeled"
+      confidence: high
+      evidence: "Уже размечен в файле, известный мобильный аналитик"
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 36
+    replies_count: 7
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Отменённое ошибочное присвоение. Судя по контексту, это могут быть реплики
+        Ksenks (SPEAKER_00) или других участников. Короткие фразы разбросаны по эпизоду.
+        Lavale не была упомянута и не представлена в этом эпизоде.
+
+      identified_as: null
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Короткие реплики похожи на паттерн Ksenks"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6125.39
+          etime: 6165.19
+          text: "То есть, например, у нас была достаточно интересная магистратура... Если эта программа вам не интересна..."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 6
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Отменённое ошибочное присвоение. Всего 2 короткие реплики (6 сек).
+        Пётр Диденко не был упомянут и не представлен в этом эпизоде.
+        Скорее всего это ошибки распознавания других участников.
+
+      identified_as: null
+      possible_matches:
+        - person_id: "unknown"
+          confidence: 0.3
+          reason: "Слишком мало данных для идентификации"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проблема с Gray
+gray_issue:
+  description: |
+    КРИТИЧЕСКАЯ ОШИБКА: Gray размечен в файле (2 реплики), но Umputun явно сказал
+    в начале "один из них ВМЕСТО Грея" - Gray отсутствовал в этом эпизоде!
+
+  evidence:
+    - timestamp: 8.3
+      quote: "Сегодня все четыре человека пришло, но один из них вместо Грея"
+    - timestamp: 12.05
+      quote: "И не просто вместо Грея"
+
+  gray_lines:
+    - stime: 545.16
+      etime: 546.18
+      text: "Нет, подожди, подожди."
+    - stime: 6048.13
+      etime: 6053.07
+      text: "Там у вас холодина была и озеро сейчас замерзало даже вот тут."
+
+  suggested_action: "Реплики Gray нужно переатрибутировать другому спикеру (вероятно Ksenks или EldarMurtazin)"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Gray"
+      issue: "Размечен как присутствующий, но явно сказано что отсутствует"
+    - speaker: "SPEAKER_00"
+      issue: "Не представлен явно, но контекст указывает на Ksenks"
+    - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+      issue: "Lavale не представлена в эпизоде, реплики ошибочны"
+    - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+      issue: "Пётр Диденко не представлен в эпизоде, реплики ошибочны"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 383
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Plushev"
+    confidence: high
+    reason: "Явное представление: 'В гостях Александр Плющев'"
+
+  - type: rename
+    episode: 383
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: "Контекст: 'Мы с Ксюшей' + обращения. Требует voice verification."
+
+  - type: delete_or_reassign
+    episode: 383
+    from_speaker: "Gray"
+    confidence: high
+    reason: "Umputun явно сказал что Gray отсутствует ('вместо Грея')"
+
+  - type: review
+    episode: 383
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    confidence: medium
+    reason: "Отменённое ошибочное присвоение, нужна voice verification"
+
+  - type: review
+    episode: 383
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    confidence: low
+    reason: "Отменённое ошибочное присвоение, слишком мало данных"
+
+# Референсные сегменты для voice comparison
+voice_reference_segments:
+  SPEAKER_04_plushev:
+    description: "Длинный монолог Плющева о первом знакомстве с интернетом"
+    stime: 261.12
+    etime: 313.67
+    duration_sec: 52.55
+    text_preview: "Для меня это было какое-то чудо, что наши студенты у нас обучались..."
+
+  SPEAKER_00_possible_ksenks:
+    description: "Диалог после упоминания 'мы с Ксюшей'"
+    stime: 61.11
+    etime: 68.49
+    duration_sec: 7.38
+    text_preview: "Какой с прошлого? С поза прошлого. Да, все записываем в тетрадочку."

--- a/validation/episodes/0300-0399/0384.yaml
+++ b/validation/episodes/0300-0399/0384.yaml
@@ -1,0 +1,276 @@
+episode: 384
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Контекст эпизода
+# Дата: 22 марта 2014 года
+# Гость: Вячеслав (Слава) - работает в Amazon AWS, преподает Java на Hexlet, ранее работал в Samsung
+# Находится в Ирландии
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray, Bobuk]
+  guests_present: [Marin_k_a, "Вячеслав (SPEAKER_02)"]
+  total_duration_sec: 7287  # ~2 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 656
+    replies_count: 267
+    pattern: consecutive
+    first_appearance_sec: 29
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Umputun в 21.86s: "Кроме Грея у нас есть Ксюша, которая всегда есть"
+        Сразу после этого SPEAKER_00 в 29.11s: "Да, я тут всегда не ухожу никуда"
+        Umputun обращается к Ксюше в 102.15s: "Ксюша, согласись..."
+        SPEAKER_00 отвечает в 106.05s
+        Marin_k_a говорит про Ксюшу в 3-м лице: "Ксюша пропала"
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 491
+    replies_count: 131
+    pattern: consecutive
+    first_appearance_sec: 43
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: null  # Новый гость, не в people.yaml
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        В 42.64s гость представляется: "Да, всем привет"
+        В 43.52s: "Меня зовут Вячеслав"
+        В 45.24s: "Ну, есть коротенькое имя Слава"
+        В 47.12s: "Я, в общем, преподаю на университете Hexlet Java, а также работаю в Амазоне на AWS"
+        В 54.35s: "В прошлом из любимого в этом подкасте Самсунга"
+        Umputun обращается к нему по имени: "Вячеслав, ответь достойно..." (277.49s)
+
+      new_guest_info:
+        name: "Вячеслав"
+        short_name: "Слава"
+        info: "Работает в Amazon AWS, преподает Java на Hexlet, ранее работал в Samsung. Живёт в Ирландии."
+        suggested_id: "vyacheslav_aws"
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1124
+    replies_count: 186
+    pattern: consecutive
+    first_appearance_sec: 110
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Marin_k_a уже есть в people.yaml как бывшая ведущая Марина.
+        Говорит про iOS разработку, GDC, пулы потоков.
+        Находится в Сиэтле (118.73s через SPEAKER_00, но контекст указывает что это её слова).
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 30
+    replies_count: 5
+    pattern: scattered
+    first_appearance_sec: 47
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Это реплики гостя Вячеслава (SPEAKER_02), ошибочно помеченные как SPEAKER_MISATTRIBUTED_PETR.
+        Первая реплика (47.12s) идёт сразу после представления Вячеслава и является частью его вступления.
+        Остальные реплики также по контексту принадлежат гостю (технические комментарии про Java, AWS).
+
+      identified_as: null
+      should_be: "SPEAKER_02"
+      confidence: high
+      evidence: |
+        47.12s: "Я, в общем, преподаю на университете Hexlet Java..." - это часть представления Вячеслава,
+        который только что сказал "Меня зовут Вячеслав" (43.52s) и "есть коротенькое имя Слава" (45.24s).
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 10
+    replies_count: 2
+    pattern: scattered
+    first_appearance_sec: 589
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Это реплики Marin_k_a, ошибочно помеченные как SPEAKER_MISATTRIBUTED_LAVALE.
+        Обе реплики появляются между репликами Marin_k_a и продолжают её мысль.
+
+      identified_as: null
+      should_be: "Marin_k_a"
+      confidence: high
+      evidence: |
+        588.9s: "Так, ну, странно, что не было в интерфейсе optional" - реплика между репликами Marin_k_a.
+        2692.55s: "То есть ты просто ему соментишь операции в очередь..." - продолжение речи Marin_k_a
+        про iOS GDC и пулы потоков (предыдущая реплика Marin_k_a в 2680.32s).
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 8
+    replies_count: 3
+    pattern: scattered
+    first_appearance_sec: 1182
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие реплики в случайных местах, вклинивающиеся между ведущими.
+        Скорее всего ошибки распознавания речи.
+
+      identified_as: null
+      should_be: null  # Неясно кто именно, нужна проверка голоса
+      confidence: low
+      evidence: |
+        1182.22s: "Понимаешь?" - между репликами Umputun
+        3107.59s: "Попил кофе?" - между репликами Umputun
+        6207.21s: "И часто... Понятно." - между репликами Gray и Umputun
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.5
+          reason: "Большинство реплик вклиниваются в речь Umputun"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Последняя реплика рядом с Gray"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6207.21
+          etime: 6211.39
+          text: "И часто... Понятно."
+
+  - speaker: "Bobuk"
+    total_duration_sec: 5
+    replies_count: 2
+    pattern: scattered
+    first_appearance_sec: 3932
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Примечание: Bobuk появляется очень поздно и мало говорит
+      # Возможно он подключился позже или это ошибка разметки
+      note: |
+        Bobuk появляется только дважды, очень поздно (3932s и 5733s).
+        Это необычно для постоянного ведущего. Возможные объяснения:
+        1. Он подключился позже
+        2. Его реплики неправильно размечены как другие спикеры
+        Требуется дополнительная проверка.
+
+      possible_matches: []
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5733.79
+          etime: 5738.03
+          text: "Это ты съел какое-то количество рабочих мест в офисе."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_00"
+      issue: "Ксюша (Ksenks) не размечена, вместо неё SPEAKER_00"
+    - speaker: "Bobuk"
+      issue: "Появляется очень поздно (3932s) и всего 2 реплики - нетипично для ведущего"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 384
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun представляет Ксюшу и SPEAKER_00 отвечает.
+      Обращения к Ксюше получают ответы от SPEAKER_00.
+      Marin_k_a говорит о Ксюше в 3-м лице.
+
+  - type: rename
+    episode: 384
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    to_speaker: "SPEAKER_02"
+    confidence: high
+    reason: |
+      Реплики являются частью непрерывной речи гостя Вячеслава при представлении.
+      SPEAKER_02 говорит имя → SPEAKER_MISATTRIBUTED_PETR про работу → SPEAKER_02 про Samsung.
+
+  - type: rename
+    episode: 384
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Marin_k_a"
+    confidence: high
+    reason: |
+      Реплики появляются между репликами Marin_k_a и продолжают её мысль
+      про iOS разработку и GDC.
+
+  - type: add_guest
+    suggested_entry:
+      id: "vyacheslav_aws"
+      canonical_name: "Vyacheslav"
+      aliases: ["Слава", "Вячеслав"]
+      real_name: "Вячеслав"
+      info: "Amazon AWS, преподаватель Hexlet (Java), ex-Samsung. Выпуск 384"
+
+  # После добавления гостя в people.yaml:
+  - type: rename
+    episode: 384
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Vyacheslav"
+    confidence: high
+    reason: "Гость представился как Вячеслав, работает в AWS, преподаёт на Hexlet"
+    depends_on: "add_guest vyacheslav_aws"
+
+# Задачи для ручной проверки
+manual_tasks:
+  - task: "Проверить голос SPEAKER_04"
+    description: "Короткие реплики - определить кому принадлежат"
+    priority: low
+
+  - task: "Проверить Bobuk"
+    description: "Всего 2 реплики, появляется поздно. Убедиться что это действительно Bobuk"
+    priority: medium
+
+  - task: "Добавить Вячеслава в people.yaml"
+    description: "Новый гость, работает в Amazon AWS, преподаёт Java на Hexlet"
+    priority: high

--- a/validation/episodes/0300-0399/0385.yaml
+++ b/validation/episodes/0300-0399/0385.yaml
@@ -1,0 +1,295 @@
+episode: 385
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray, Bobuk]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 6500  # ~1:48:20
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 566
+    replies_count: 229
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Umputun несколько раз обращается к "Ксюше", а SPEAKER_00 отвечает:
+        - 245-252s: "Ксюша, такое быть в этом великое и могучее русское языка" -> SPEAKER_00: "Облако трясения, это можно, конечно"
+        - 309-315s: "Ксюша, что за новость была?" -> SPEAKER_00: "Новый сервис от Google, а ты имеешь в виду?"
+        - 393s: "Ксюша, записывай за мной" -> SPEAKER_00 продолжает диалог
+        Женский голос, участвует в обсуждениях как ведущая.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 974
+    replies_count: 149
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Уже идентифицирована в people.yaml как "Марина - бывшая ведущая".
+        Активно участвует в обсуждении тем про Google Cloud, Microsoft Office, iPad.
+        Явно женский голос, отличный от Ksenks (SPEAKER_00).
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 35
+    replies_count: 8
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Эльдар Муртазин отсутствует в этом выпуске. Помечено как MISATTRIBUTED,
+        что означает ошибочное присвоение. Реплики разбросаны и по контексту
+        принадлежат либо Marin_k_a, либо Ksenks (SPEAKER_00).
+        Например, 2335s: "Ну, у них чеки ведь и самые параноидальные" - женский голос в контексте обсуждения.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.6
+          reason: "Контекст и расположение рядом с репликами Marin_k_a"
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Может быть Ksenks (SPEAKER_00)"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3855.9
+          etime: 3870.0
+          text: "А юбилейная тема у нас сегодня вообще-то весь мир отмечал и продолжает отмечать..."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 26
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Пётр Диденко отсутствует в этом выпуске. Помечено как MISATTRIBUTED.
+        Реплики по контексту принадлежат Marin_k_a - например, 2873s продолжает
+        её мысль про Office 365 и iPad.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.8
+          reason: "Реплика 2873s непосредственно продолжает мысль Marin_k_a про Office 365"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2873.0
+          etime: 2884.0
+          text: "То есть пользователей iPad достаточно много, и если они смогут их законвертить в пользователей Office 365, для них это будет большое дело."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 16
+    replies_count: 4
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Лаваль отсутствует в этом выпуске. Помечено как MISATTRIBUTED.
+        Реплики по контексту принадлежат Marin_k_a или Ksenks.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.7
+          reason: "Контекст и расположение рядом с репликами Marin_k_a (886s)"
+        - person_id: "ksenks"
+          confidence: 0.3
+          reason: "Может быть Ksenks"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 8
+    replies_count: 4
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Очень короткие реплики (2-3 сек каждая), разбросаны по всему эпизоду.
+        Типичные ошибки распознавания - фрагменты перебивок или коротких реакций.
+        "Если вы хотите, чтобы они работали, заплатите деньги" (2191s) - может быть Gray.
+        "Постоянно в контакте с Фейсбуком" (5472s) - короткая перебивка.
+        "Он пойдет в суд" (6486s) - короткая реакция.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Некоторые реплики похожи на перебивки Gray"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Женский голос в 5472s рядом с репликами Marin_k_a"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика "Молодец" (3361s) длительностью 2.5 секунды.
+        Типичная ошибка распознавания - односложная реакция.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Bobuk"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "bobuk"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Единственная реплика в 4867s: "Нет, что значит против?"
+        Контекст: Umputun говорит о Яндексе и брендинге, возможно Bobuk
+        кратко подключился к обсуждению или это ошибка распознавания.
+        Bobuk отсутствует в начале (передаёт приветы через Umputun),
+        но мог подключиться позже.
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Может быть реплика Gray, неверно атрибутированная"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 4867.65
+          etime: 4869.51
+          text: "Нет, что значит против?"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_00"
+      issue: |
+        SPEAKER_00 - это Ksenks (Ксюша), но не размечена правильно.
+        Umputun обращается к "Ксюше" в начале, она отвечает как SPEAKER_00.
+    - speaker: "Bobuk"
+      issue: |
+        Bobuk упоминается в начале как отсутствующий (передаёт приветы через Umputun),
+        но появляется одна реплика в 4867s. Требует проверки - подключился ли он позже
+        или это ошибка атрибуции.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 385
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun многократно обращается к "Ксюше", и SPEAKER_00 отвечает.
+      Примеры: 245s, 309s, 393s, 428s. Женский голос ведущей.
+
+  - type: rename
+    episode: 385
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    to_speaker: "Marin_k_a"
+    confidence: medium
+    reason: |
+      Реплика 2873s продолжает мысль Marin_k_a про Office 365 и iPad.
+      Пётр Диденко не участвовал в этом выпуске.
+
+  - type: delete_or_merge
+    episode: 385
+    speaker: "SPEAKER_03"
+    confidence: low
+    reason: |
+      Очень короткие реплики (2-3 сек), разбросаны по эпизоду.
+      Скорее всего ошибки сегментации. Требует voice comparison.
+
+  - type: delete_or_merge
+    episode: 385
+    speaker: "SPEAKER_05"
+    confidence: high
+    reason: |
+      Единственная реплика "Молодец" 2.5 сек - ошибка распознавания.
+
+# Примечания
+notes: |
+  Этот выпуск (385, 29 марта 2014) ведут Umputun, Gray и Ksenks.
+  Гостья - Marin_k_a (Марина, бывшая ведущая).
+  Bobuk отсутствует (передаёт приветы в начале через Umputun), но есть одна
+  реплика в 4867s - требует проверки.
+
+  Основная проблема: SPEAKER_00 (229 реплик, 566 сек) - это Ksenks,
+  но не размечена корректно. Рекомендуется переименовать.
+
+  SPEAKER_MISATTRIBUTED_* - это маркеры ошибочных атрибуций из предыдущих
+  итераций очистки. Большинство из них принадлежат Marin_k_a или Ksenks.

--- a/validation/episodes/0300-0399/0386.yaml
+++ b/validation/episodes/0300-0399/0386.yaml
@@ -1,0 +1,218 @@
+episode: 386
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7621  # ~2 часа 7 минут
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_06"
+    total_duration_sec: 878
+    replies_count: 174
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: null  # Нет person_id в people.yaml для этого Алексея
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        В 75s Umputun говорит: "И зашел на огонек Алексей, который к нам на гиковские выпуски."
+        В 95s: "Вам не интересно про телефончики, Алексей?"
+        В 113s: "Алексей, тебя обманули."
+
+        Гость активно участвует в технических дискуссиях о Python, IPython, моделировании,
+        базах данных. Говорит о "гиковских" темах, что соответствует представлению.
+
+      possible_matches:
+        - person_id: "alek_sys"
+          confidence: 0.3
+          reason: "Имя совпадает (Алексей), но Alek.sys - это постоянный ведущий, и контекст не указывает на него"
+
+      voice_task:
+        needed: true
+        reason: "Нужно создать person_id для этого гостя и подтвердить идентификацию"
+        reference_segment:
+          stime: 1153.48
+          etime: 1164.07
+          text: "Потому что я помню, в институте еще давно-давно всякие системы для моделирования, я даже не помню, как они назывались, назывался предмет такой математическое моделирование."
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 173
+    replies_count: 42
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. В начале (38s) Umputun говорит: "у нас есть Ксюша, которая любую логику..."
+           Сразу после этого (45s) отвечает SPEAKER_00.
+
+        2. В реплике на 1098s SPEAKER_00 использует женский род:
+           "Ну просто я вот пыталась понять, чем IPython как-то лучше..."
+
+        3. В файле 386_cc.json НЕТ спикера "Ksenks", хотя она была представлена.
+           Значит её реплики размечены как SPEAKER_00.
+
+        4. Marin_k_a (также женщина) уже идентифицирована отдельно и чередуется
+           с SPEAKER_00 - это две разные женщины.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 51
+    replies_count: 11
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Реплики содержат технические темы:
+        - MongoDB, "Монге" (2869s)
+        - Модели данных, джойны (2920s)
+        - PostgreSQL коммитфесты (4340s)
+
+        Метка SPEAKER_MISATTRIBUTED_ELDAR означает, что эти реплики ранее были
+        ошибочно приписаны Эльдару Муртазину, затем отменены.
+
+        Скорее всего это тот же гость Алексей (SPEAKER_06), т.к.:
+        - Темы пересекаются (базы данных, технические вопросы)
+        - Эльдар Муртазин - мобильный аналитик, а тут темы БД
+        - В этом выпуске был только один гость Алексей
+
+      possible_matches:
+        - person_id: null  # То же что SPEAKER_06 - гость Алексей
+          confidence: 0.7
+          reason: "Скорее всего тот же человек что SPEAKER_06 (гость Алексей), ошибочно разделённый распознаванием"
+
+      voice_task:
+        needed: true
+        reason: "Сравнить голос с SPEAKER_06 для подтверждения что это один человек"
+        reference_segment:
+          stime: 4340.01
+          etime: 4345.64
+          text: "Чтобы пройти через коммитфесты, нужно иметь очень много усидчивости и нервов."
+
+  - speaker: "SPEAKER_07"
+    total_duration_sec: 3
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Обе реплики - эхо фраз Bobuk:
+        1. В 3530s SPEAKER_07: "Что вы делаете с этими письмами?"
+           За 3 секунды до этого (3527s) Bobuk: "А что вы делаете с этим писем?"
+           Это одна и та же фраза, дублирование распознавания.
+
+        2. В 7621s: "Ну, конечно." - односложная реакция, типичная ошибка.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика - эхо фразы Bobuk:
+        В 2527s Bobuk: "Скажите, какие слова-то?"
+        В 2528s SPEAKER_04: "Да, слова-то какие?"
+
+        Практически идентичная фраза, интервал <1 секунды.
+        Это артефакт распознавания, не отдельный спикер.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "Ksenks"
+      issue: "Представлена как 'Ксюша' в начале, но все реплики размечены как SPEAKER_00"
+    - speaker: "SPEAKER_06"
+      issue: "Представлен как 'Алексей' в 75s, но нет соответствующего person_id в people.yaml для этого конкретного гостя"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 386
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      SPEAKER_00 использует женский род ("я пыталась"), появляется сразу после
+      представления Ксюши, и Ksenks отсутствует в файле несмотря на представление в начале
+
+  - type: rename
+    episode: 386
+    from_speaker: "SPEAKER_07"
+    to_speaker: "Bobuk"
+    confidence: medium
+    reason: "Обе реплики - эхо/дублирование фраз Bobuk, артефакт распознавания"
+
+  - type: rename
+    episode: 386
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Bobuk"
+    confidence: medium
+    reason: "Единственная реплика - эхо фразы Bobuk с интервалом <1 секунды"
+
+# Задачи для ручной проверки
+manual_review_tasks:
+  - task: "create_person"
+    description: |
+      Создать person_id для гостя Алексея из этого выпуска.
+      Нужно определить, кто этот Алексей - возможно он появлялся в других "гиковских" выпусках.
+      Umputun говорит: "зашел на огонек Алексей, который к нам на гиковские выпуски"
+      - это указывает что гость был и раньше.
+
+  - task: "voice_comparison"
+    description: |
+      Сравнить голоса SPEAKER_06 и SPEAKER_MISATTRIBUTED_ELDAR.
+      Если это один человек - объединить под одним именем (Алексей/guest_id).
+      Если разные - идентифицировать SPEAKER_MISATTRIBUTED_ELDAR отдельно.
+
+  - task: "verify_ksenks"
+    description: |
+      Прослушать сегменты SPEAKER_00 для подтверждения что это Ksenks.
+      Reference: 1094-1115s (разговор об IPython, женский род).

--- a/validation/episodes/0300-0399/0387.yaml
+++ b/validation/episodes/0300-0399/0387.yaml
@@ -1,0 +1,247 @@
+episode: 387
+status: has_tasks
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7600  # ~2h 6min based on last timestamps
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 627
+    replies_count: 112
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "known_guest"
+      confidence: high
+      evidence: "Известная ведущая (Марина). Упоминается как 'Ксюша' в начале выпуска (44.91s). В people.yaml указана как бывшая ведущая."
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 445
+    replies_count: 65
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: null
+      identification_method: "introduction"
+      confidence: high
+      evidence: "Представился в 1863.81s: 'Меня зовут Николай, и я руководитель направления облачных услуг этой компании [WebZilla]'"
+
+      possible_matches:
+        - person_id: "nikolay_webzilla"
+          confidence: 0.95
+          reason: "Явное представление. Гость от компании WebZilla."
+
+      voice_task:
+        needed: false
+
+    suggested_name: "NikolayWebZilla"
+    suggested_real_name: "Николай"
+    suggested_info: "Руководитель направления облачных услуг WebZilla, выпуск 387"
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 233
+    replies_count: 52
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: null
+      identification_method: "introduction"
+      confidence: high
+      evidence: "Представился в 1856.3s: 'Добрый день, меня зовут Константин Безрученко, я CTO компании WebZilla'"
+
+      possible_matches:
+        - person_id: "konstantin_bezruchenko"
+          confidence: 0.95
+          reason: "Явное представление с полным именем и должностью."
+
+      voice_task:
+        needed: false
+
+    suggested_name: "KonstantinBezruchenko"
+    suggested_real_name: "Константин Безрученко"
+    suggested_info: "CTO WebZilla, выпуск 387"
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 384
+    replies_count: 134
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибка распознавания. Это реплики Marin_k_a (Ksenks). Реплики в 147-157s являются продолжением речи Marin_k_a о том, как она узнала о Heartbleed. Также SPEAKER_01 отвечает на вопросы, заданные Ксюше."
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        - 147.17s: 'Поэтому меня не будили' — продолжение фразы Marin_k_a (141.77s: 'Нет, у меня нет серверов...')
+        - 148.61s: 'Я узнала об этом...' — ответ на вопрос Umputun к Ксюше
+        - 789.26s: технический контекст в диалоге о Heartbleed
+        - 815.28s: 'Просто Финн медленный' — шутка в стиле Ксюши
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 42
+    replies_count: 7
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Маркер ошибочной атрибуции. Реплики были ранее ошибочно приписаны Lavale, но это не она. Судя по контексту (технические реплики о Cloudflare, конференциях), это скорее один из ведущих."
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.6
+          reason: "Некоторые реплики похожи по стилю на Marin_k_a (разговор о конференциях, 5026.7s)"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Технические реплики о Cloudflare могут принадлежать Gray"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5026.7
+          etime: 5035.28
+          text: "Но идея в том, что у тебя есть неделя, когда ты действительно, ну, то есть полностью погружен в это, и очень, ну, это действительно полезно."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 16
+    replies_count: 6
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Маркер ошибочной атрибуции. Реплики были ранее ошибочно приписаны Эльдару Муртазину, но он не участвовал в этом выпуске."
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.5
+          reason: "Реплика 5428.07s 'Ты понимаешь, да, Ксюша...' — обращение к Ксюше, может быть кто-то из ведущих"
+        - person_id: "gray"
+          confidence: 0.4
+          reason: "Некоторые реплики типичны для Gray (7122.96s: 'Давайте лучше про...')"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5428.07
+          etime: 5434.81
+          text: "Ты понимаешь, да, Ксюша, что в этот момент тебя возненавидели все разработчики, у которых запланировано более одной командировки на конференцию?"
+
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 7
+    replies_count: 5
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие разрозненные реплики: 'Пи, пи, пи' (звуковой эффект цензуры), 'Зачем?', 'Ну, маленькая, да', 'Ну да', 'Убежденность'. Скорее всего ошибки распознавания или реплики ведущих."
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "Некоторые короткие реплики могут быть от Marin_k_a"
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_07"
+    total_duration_sec: 0
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Очень короткие реплики (<1 сек): 'Ха-ха-ха', 'Да', 'Зато?'. Это аудио-артефакты или ошибки распознавания смеха/коротких реакций."
+
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Marin_k_a"
+      issue: "Называется 'Ксюша' в начале выпуска (44.91s), но в справочнике это Марина. Возможно путаница имён или Ksenks отсутствует, а Марина выступает как соведущая."
+
+    - speaker: "SPEAKER_03, SPEAKER_04"
+      issue: "Гости от WebZilla (Николай и Константин Безрученко) представились в ~1856-1868s. Нужно добавить в people.yaml."
+
+    - speaker: "SPEAKER_01"
+      issue: "134 реплики неправильно отнесены к SPEAKER_01 вместо Marin_k_a. Требуется bulk rename."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 387
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Marin_k_a"
+    confidence: high
+    reason: "Реплики являются продолжением речи Marin_k_a или ответами на вопросы к ней. Контекст однозначен."
+
+  - type: rename
+    episode: 387
+    from_speaker: "SPEAKER_03"
+    to_speaker: "NikolayWebZilla"
+    confidence: high
+    reason: "Явное представление: 'Меня зовут Николай, и я руководитель направления облачных услуг этой компании'"
+
+  - type: rename
+    episode: 387
+    from_speaker: "SPEAKER_04"
+    to_speaker: "KonstantinBezruchenko"
+    confidence: high
+    reason: "Явное представление: 'Добрый день, меня зовут Константин Безрученко, я CTO компании WebZilla'"
+
+  - type: rename
+    episode: 387
+    from_speaker: "SPEAKER_00"
+    to_speaker: "SPEAKER_99"
+    confidence: medium
+    reason: "Короткие артефактные реплики. Первая реплика 'Пи, пи, пи' — явно звук цензуры."
+
+  - type: rename
+    episode: 387
+    from_speaker: "SPEAKER_07"
+    to_speaker: "SPEAKER_99"
+    confidence: high
+    reason: "Реплики <1 сек — смех и односложные реакции, не являющиеся речью."
+
+# Требуемые дополнения в people.yaml
+new_guests_to_add:
+  - id: "nikolay_webzilla"
+    canonical_name: "NikolayWebZilla"
+    aliases: ["Николай"]
+    real_name: "Николай"
+    info: "Руководитель направления облачных услуг WebZilla, выпуск 387"
+
+  - id: "konstantin_bezruchenko"
+    canonical_name: "KonstantinBezruchenko"
+    aliases: ["Безрученко", "Константин Безрученко"]
+    real_name: "Константин Безрученко"
+    info: "CTO WebZilla, выпуск 387"
+
+# Примечания
+notes: |
+  Выпуск 387 от 12 апреля 2014 года. Основная тема — Heartbleed.
+
+  Участники:
+  - Ведущие: Umputun, Bobuk, Gray
+  - Соведущая: Marin_k_a (Марина, но называют "Ксюша" — возможно ник)
+  - Гости: Константин Безрученко (CTO WebZilla) и Николай (руководитель облачных услуг WebZilla)
+
+  Гости от WebZilla появляются с ~1852s (30:52) и участвуют в техническом обсуждении.
+
+  SPEAKER_MISATTRIBUTED_* — маркеры ранее исправленных ошибок атрибуции.
+  Требуется дополнительный voice comparison для определения правильного спикера.

--- a/validation/episodes/0300-0399/0388.yaml
+++ b/validation/episodes/0300-0399/0388.yaml
@@ -1,0 +1,185 @@
+episode: 388
+status: needs_review
+analyzed_at: "2026-01-25T18:30:00Z"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7700  # приблизительно 2ч 8мин
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_00"
+    total_duration_sec: 688
+    replies_count: 258
+    pattern: consecutive  # распределены по всему выпуску
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. Umputun обращается "Ксюша, ты же не зря тут" (125s) -> SPEAKER_00 отвечает
+        2. SPEAKER_00 использует женский род: "я отказывалась", "я не поняла"
+        3. EldarMurtazin говорит "Обычно Ксюша кушать хочет" (8657s) -> SPEAKER_00 отвечает "Ну, я могу еще потерпеть" (8660s)
+        4. Многочисленные обращения к "Ксюша" по всему выпуску с ответами SPEAKER_00
+        5. Ksenks отсутствует в разметке, но очевидно присутствует в выпуске
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 659
+    replies_count: 123
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Marin_k_a (Марина) - известная бывшая ведущая подкаста.
+        123 реплики распределены по всему выпуску.
+        Участвует в обсуждениях на технические темы.
+        Корректная разметка.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 92
+    replies_count: 14
+    pattern: scattered  # разрозненные реплики по выпуску
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Эльдар Муртазин - известный мобильный аналитик.
+        В этом выпуске НЕ был представлен как гость.
+        Реплики вклиниваются между репликами ведущих без контекста.
+        Пример: "Обычно Ксюша кушать хочет" (8657s) - это явно шутка одного из ведущих, не гостя.
+        Пример: "Любой способ включает, кстати говоря... Там про радиотип" (3551s) - между репликами Gray.
+        92 сек > threshold 60 сек, поэтому не был переименован в SPEAKER_MISATTRIBUTED_ELDAR.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.4
+          reason: "Некоторые реплики по стилю похожи на Umputun"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Возможно ошибка voice recognition"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Реплики рядом с репликами Gray"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 7444.26
+          etime: 7463.45
+          text: "Нет, ну подожди, ты... Поэтому нельзя говорить, что что-то не летит... Потому что из того, что следит за глазами, потому что самое популярное из того, что следит за глазами, это всякие Samsung, по-моему, Galaxy S3, Galaxy S4 и S5, видимо, тоже."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика: "Я тоже не поняла" (7057s) - 1.5 сек.
+        Контекст: Gray говорит "Извините" -> SPEAKER_MISATTRIBUTED_LAVALE "Я тоже не поняла" -> Gray "Ты сказала «блок»"
+        Это явно женщина (одна из двух: Ksenks или Marin_k_a).
+        Lavale в этом выпуске не представлена.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "Женский род, вписывается в контекст разговора. SPEAKER_00 (Ksenks) говорит рядом на 7045s"
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "Marin_k_a также присутствует в выпуске"
+
+      voice_task:
+        needed: false  # слишком короткая реплика для voice comparison
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Ksenks"
+      issue: "Ведущая Ksenks очевидно присутствует (многочисленные обращения по имени), но размечена как SPEAKER_00"
+
+    - speaker: "EldarMurtazin"
+      issue: "Гость EldarMurtazin не был представлен, но имеет 14 реплик (92 сек). Вероятно ошибка voice recognition."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 388
+    from_speaker: "SPEAKER_00"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      SPEAKER_00 = Ksenks на основе:
+      - Прямых обращений "Ксюша" с ответами SPEAKER_00
+      - Женского рода в речи SPEAKER_00
+      - Отсутствия Ksenks в разметке при явном присутствии в выпуске
+      - 258 реплик, 688 сек - типичный объём участия ведущей
+
+  - type: rename
+    episode: 388
+    from_speaker: "EldarMurtazin"
+    to_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    confidence: medium
+    reason: |
+      EldarMurtazin не был представлен как гость.
+      14 реплик (92 сек) разбросаны между репликами ведущих.
+      Требуется voice comparison для определения реального спикера.
+      Threshold 60 сек не сработал, нужно ручное переименование.
+
+  - type: rename
+    episode: 388
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      Единственная реплика "Я тоже не поняла" (7057s).
+      Контекст: Gray "Ты сказала «блок»" - обращение к женщине.
+      SPEAKER_00 (=Ksenks) говорит рядом на 7045s.
+      Скорее всего это Ksenks, но уверенность средняя.
+
+# Примечания
+notes: |
+  Эпизод 388 от 19.04.2014 - день рождения Bobuk.
+  Ведущие: Umputun, Bobuk, Gray, Ksenks (размечена как SPEAKER_00).
+  Гости: Marin_k_a (бывшая ведущая Марина).
+
+  Основная проблема: Ksenks размечена как SPEAKER_00.
+  Вторичная проблема: EldarMurtazin (14 реплик) - ложноположительный voice match.
+
+  Рекомендуется применить suggested_rules после voice verification для EldarMurtazin.

--- a/validation/episodes/0300-0399/0389.yaml
+++ b/validation/episodes/0300-0399/0389.yaml
@@ -1,0 +1,264 @@
+episode: 389
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  # Примечание: Ksenks присутствует, но размечена как Marin_k_a и SPEAKER_05
+  total_duration_sec: 6922  # ~1.9 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1185
+    replies_count: 221
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибочная атрибуция. По контексту (обращения 'Ксюша', 'Ксюшенька' от Umputun и Bobuk) это Ksenks, а не Marin_k_a. В эпизодах 409+ та же участница размечена как Ksenks."
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. Umputun (10.84s): "Ксюша пришла, как она приходит всегда"
+        2. Umputun (42.03s): "Ксюша, ты тоже молодец" -> отвечает Marin_k_a
+        3. Umputun (2762.9s): "Следующая тема, Ксюша, будет что?" -> отвечает Marin_k_a
+        4. Bobuk (4269.3s): "Ксюш, ты можешь быстро ответить..." -> отвечает SPEAKER_05
+        5. В эпизодах 388, 390, 408 также Marin_k_a при обращениях "Ксюша"
+        6. С эпизода 409 разметка меняется на Ksenks
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 523
+    replies_count: 245
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибка автоматического распознавания. Тот же спикер что и Marin_k_a (т.е. Ksenks). Женский голос, говорит 'я вспомнила', 'я думала'. Отвечает на обращение 'Ксюш' от Bobuk."
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. SPEAKER_05 (538.74s): "Вирчуал ПС, да, я вспомнила" - женский род
+        2. SPEAKER_05 (760.92s): "Да, я даже думала, что там разных заносит" - женский род
+        3. Bobuk (4269.3s): "Ксюш, ты можешь быстро ответить..." -> SPEAKER_05 (4285.58s): "Я вообще первый раз это слышу..."
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 24
+    replies_count: 7
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      error_reason: null
+      # SPEAKER_MISATTRIBUTED_* - это уже отменённые ошибочные атрибуции,
+      # реплики требуют дальнейшего анализа для идентификации
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.4
+          reason: "Короткие реплики, могут быть ошибками распознавания Bobuk"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Возможно ошибки распознавания Umputun"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 324.52
+          etime: 329.16
+          text: "Слушай, ну выглядит он как-то как Windows Phone, прям вот этот Nokia X, то есть там-то типа оболочка такая натянута."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 1
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Очень короткие односложные реплики (0.5-1 сек). Скорее всего ошибки распознавания одного из ведущих."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Реплики: "Сразу." (0.5 сек), "Давно пора." (1 сек)
+        Слишком короткие для идентификации голоса
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Типичные короткие реакции в контексте диалога"
+
+      voice_task:
+        needed: false
+        # Слишком короткие реплики для voice comparison
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 11
+    replies_count: 7
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие реплики разбросаны по эпизоду. Вероятно ошибки распознавания Ksenks или одного из ведущих."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        Примеры: "Да." (0.24 сек), "А 389 было сказано?" (3 сек), "А куда он уходит?" (0.7 сек)
+        Короткие вопросы и реакции
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.5
+          reason: "Несколько реплик могут быть Ksenks (как и Marin_k_a/SPEAKER_05)"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Короткие реакции типа 'Да'"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 65.78
+          etime: 68.92
+          text: "А 389 было сказано?"
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 4
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Только 2 очень коротких реплики за весь эпизод. Явная ошибка распознавания."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        3776.3s: "Все прекрасно." (3 сек)
+        6090.5s: "Для вас, дорогие слушатели." (1 сек)
+        Вторая фраза звучит как джингл или outro
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.6
+          reason: "'Для вас, дорогие слушатели' - типичная фраза ведущего"
+
+      voice_task:
+        needed: false
+        # Слишком короткие и разбросанные для voice comparison
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 2
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Только 3 очень коротких реплики (<1 сек каждая). Явная ошибка распознавания."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: |
+        718.2s: "Не знаю." (0.4 сек)
+        2221.2s: "Так, а зачем тебе три?" (1.5 сек)
+        5317.3s: "Через iCloud?" (0.2 сек)
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Вопросительные реплики могут быть Ksenks"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Короткие вопросы"
+
+      voice_task:
+        needed: false
+        # Слишком короткие для voice comparison
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Marin_k_a"
+      issue: |
+        КРИТИЧЕСКАЯ ПРОБЛЕМА: Участница размечена как Marin_k_a, но по контексту это Ksenks (Ксюша).
+        Ведущие постоянно обращаются к ней "Ксюша", "Ксюшенька".
+        Это систематическая ошибка в эпизодах до 409 — в них Ksenks ошибочно называется Marin_k_a.
+        Требуется глобальное исправление в эпизодах 388-408 (и возможно раньше).
+    - speaker: "SPEAKER_05"
+      issue: |
+        Тот же человек что и Marin_k_a (Ksenks). Разные реплики одной участницы
+        попали в разные спикерские слоты из-за ошибок автоматического распознавания.
+    - speaker: "Gray"
+      issue: "Gray отсутствует в этом эпизоде (что нормально, он не был на всех выпусках)"
+    - speaker: "Alek.sys"
+      issue: "Alek.sys отсутствует в этом эпизоде (появился с выпуска 410)"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 389
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Ведущие обращаются к участнице как "Ксюша"/"Ксюшенька".
+      Ksenks = Ксения по справочнику people.yaml.
+      С эпизода 409 та же участница размечена как Ksenks.
+
+  - type: rename
+    episode: 389
+    from_speaker: "SPEAKER_05"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Женский голос (говорит "я вспомнила", "я думала").
+      Отвечает на обращение "Ксюш" от Bobuk.
+      Тот же человек что и Marin_k_a.
+
+  - type: rename
+    episode: 389
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "Bobuk"
+    confidence: medium
+    reason: |
+      Очень короткие реплики ("Сразу", "Давно пора"),
+      типичные для быстрых реакций в диалоге.
+      Вероятно Bobuk, но требует voice verification.
+
+# Глобальные рекомендации (выходят за рамки этого эпизода)
+global_recommendations:
+  - issue: "Marin_k_a vs Ksenks confusion"
+    description: |
+      В эпизодах до 409 участница Ksenks (Ксюша) ошибочно размечена как Marin_k_a.
+      Это подтверждается контекстом (обращения "Ксюша") в эпизодах 388, 389, 390, 408.
+      С эпизода 409 разметка корректна (Ksenks).
+    affected_episodes: "предположительно 106-408"
+    recommendation: |
+      1. Проверить, есть ли в каких-либо эпизодах НАСТОЯЩАЯ Марина
+      2. Если нет — переименовать все Marin_k_a -> Ksenks в затронутых эпизодах
+      3. Обновить participants.md с корректным диапазоном эпизодов для Ksenks

--- a/validation/episodes/0300-0399/0390.yaml
+++ b/validation/episodes/0300-0399/0390.yaml
@@ -1,0 +1,226 @@
+episode: 390
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  # Ksenks присутствует, но размечена как Marin_k_a/SPEAKER_02/SPEAKER_01
+  total_duration_sec: 7060  # ~2 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 571
+    replies_count: 83
+    pattern: consecutive  # Чередуется с SPEAKER_02
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибочная атрибуция. Umputun многократно обращается к 'Ксюша' (Ksenks) на протяжении всего выпуска (183s, 1580s, 1701s, 2146s, 2249s, 2336s, 2528s, 3178s, 3752s и др.), а Марина ни разу не упоминается. В начале эпизода Umputun говорит 'выпуск 390 в классическом полном составе'. Контент реплик соответствует участию в дискуссии как ведущей."
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "183s Umputun: 'Ну что, Ксюша, хочу тебя спросить, как самую молодую' -> SPEAKER_02 отвечает"
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 509
+    replies_count: 190
+    pattern: consecutive  # Чередуется с Marin_k_a
+
+    analysis:
+      is_error: true
+      error_reason: "Тот же голос что и Marin_k_a, разбитый системой распознавания. Реплики идут вперемешку с Marin_k_a, формируя единую линию диалога."
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: "186s после обращения Umputun к 'Ксюша' отвечает SPEAKER_02: 'Я тоже, да', затем 'Я не так молода'"
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 18
+    replies_count: 9
+    pattern: scattered  # Короткие реплики в случайные моменты
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие реплики разбросаны по эпизоду. Одна реплика явно женского рода (2367s: 'я прошла сверху на горы и спустилась') указывает на женский голос - скорее всего тоже Ksenks, но требуется voice comparison."
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: "2367s: 'Ну, ладно, я прошла сверху на горы и спустилась с другой стороны' - женский род"
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.7
+          reason: "Женский род в речи, контекст диалога"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2366.62
+          etime: 2370.94
+          text: "Да, конечно. Ну, ладно, я прошла сверху на горы и спустилась с другой стороны."
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 4
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Очень короткие реплики (<2 сек каждая), разбросаны. Скорее всего ошибки распознавания одного из ведущих."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Возможно тот же голос"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Возможно Gray"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6878.19
+          etime: 6880.27
+          text: "Слушай, а не страшно ли? Нет?"
+
+  - speaker: "SPEAKER_07"
+    total_duration_sec: 3
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Очень короткие односложные реплики (<1 сек): 'Кошмар какой-то', 'Не знаю', 'Давай'. Типичные ошибки распознавания."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.4
+          reason: "Короткие реакции могут быть от любого ведущего"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Короткие реакции могут быть от любого ведущего"
+
+      voice_task:
+        needed: false  # Слишком короткие для идентификации
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Одна реплика (7047s: 'Ну, к счастью, не последнего'). Название спикера указывает на ранее отменённую ошибочную атрибуцию Эльдару Муртазину. Эльдар не участвует в этом эпизоде."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: "Контекст: Umputun говорит 'У нас много неосмотренного', затем эта реплика, затем Gray продолжает"
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Реплика между Umputun и Gray, скорее всего Gray"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Возможно Bobuk"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 7047.47
+          etime: 7049.47
+          text: "Ну, к счастью, не последнего."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Ksenks"
+      issue: "Не размечена как Ksenks. Вместо неё: Marin_k_a (83 реплики), SPEAKER_02 (190 реплик), возможно SPEAKER_01 (9 реплик). Umputun многократно обращается к 'Ксюша', подтверждая её присутствие."
+    - speaker: "Marin_k_a"
+      issue: "Марина не упоминается в эпизоде, но размечена как спикер. Это ошибка - на самом деле это Ksenks."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 390
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Umputun многократно обращается к 'Ксюша', Марина не упоминается. В начале: 'полный классический состав'."
+
+  - type: rename
+    episode: 390
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Тот же голос что Marin_k_a, чередуются в диалогах. Umputun обращается к 'Ксюша' перед репликами SPEAKER_02."
+
+  - type: rename
+    episode: 390
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: "Женский род в речи ('прошла', 'спустилась'). Требуется voice comparison для подтверждения."
+
+  - type: rename
+    episode: 390
+    from_speaker: "SPEAKER_05"
+    to_speaker: "SPEAKER_UNIDENTIFIED"
+    confidence: low
+    reason: "Слишком короткие реплики для идентификации без voice comparison."
+
+  - type: rename
+    episode: 390
+    from_speaker: "SPEAKER_07"
+    to_speaker: "SPEAKER_UNIDENTIFIED"
+    confidence: low
+    reason: "Односложные реплики, невозможно идентифицировать без voice comparison."
+
+  - type: rename
+    episode: 390
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "SPEAKER_UNIDENTIFIED"
+    confidence: low
+    reason: "Одна короткая реплика, требуется voice comparison. Скорее всего Gray или Bobuk."
+
+# Комментарии
+notes: |
+  Главная проблема эпизода: Ksenks полностью отсутствует как спикер, хотя:
+  1. Umputun в начале говорит "выпуск 390 в классическом полном составе"
+  2. Umputun многократно обращается к "Ксюша" (17+ раз по тексту)
+  3. Marin_k_a (Марина) ни разу не упоминается
+
+  Реплики Ksenks распределены между:
+  - Marin_k_a: 83 реплики, 571 сек
+  - SPEAKER_02: 190 реплик, 509 сек
+  - SPEAKER_01: 9 реплик, 18 сек (вероятно)
+
+  Итого ~1080 сек (~18 минут) - соответствует типичному участию ведущей.
+
+  Рекомендация: объединить Marin_k_a и SPEAKER_02 в Ksenks с высокой уверенностью.
+  SPEAKER_01 требует voice comparison для подтверждения.

--- a/validation/episodes/0300-0399/0391.yaml
+++ b/validation/episodes/0300-0399/0391.yaml
@@ -1,0 +1,217 @@
+episode: 391
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7311  # ~2 часа
+  notes: |
+    Umputun представляет "Ксюша и Бобук" в начале эпизода (56.95s).
+    Однако в разметке присутствует Marin_k_a (бывшая ведущая Марина).
+    SPEAKER_01 активно участвует в обсуждении и отвечает на обращения "Ксюша".
+    Вероятно, SPEAKER_01 = Ksenks.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 1040
+    replies_count: 417
+    pattern: consecutive
+    first_appearance_sec: 65.56
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. Umputun в начале представляет "Ксюша и Бобук" (56.95s)
+        2. На обращение "Ксюша, расскажи мне..." (262.36s) отвечает SPEAKER_01 (271.7s)
+        3. Многочисленные обращения Umputun к "Ксюша" с ответами от SPEAKER_01
+        4. 417 реплик, 1040 сек - объём соответствует со-ведущему
+
+        ВАЖНО: Одна аномалия - в 3046.26s SPEAKER_01 говорит "Ты меня прости, Ксюша" -
+        это скорее всего ошибка diarization (реплика Марины ошибочно приписана SPEAKER_01).
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1366
+    replies_count: 230
+    pattern: consecutive
+    first_appearance_sec: 79.26
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "existing_markup"
+      confidence: high
+      evidence: |
+        Спикер уже размечен как Marin_k_a (бывшая ведущая Марина).
+        230 реплик, 1366 сек - объём соответствует активному участнику.
+        Участвует в обсуждениях наравне с ведущими.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 4
+    replies_count: 3
+    pattern: scattered
+    first_appearance_sec: 88.55
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие изолированные реплики (1-2 сек каждая) в случайные моменты.
+        Lavale не участвует в этом эпизоде - в начале представлены только
+        "Ксюша и Бобук", плюс присутствует Марина (Marin_k_a).
+        Это ошибочные присвоения, которые уже помечены как MISATTRIBUTED.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Короткие реплики могут быть от любого участника"
+        - person_id: "marin_k_a"
+          confidence: 0.4
+          reason: "Короткие реплики могут быть от любого участника"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+        reason: "Слишком короткие реплики для voice comparison"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+    first_appearance_sec: 1656.61
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одиночная реплика 1.5 сек.
+        Эльдар Муртазин не участвует в этом эпизоде.
+        Это ошибочное присвоение, которое уже помечено как MISATTRIBUTED.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Реплика между репликами Bobuk об апелляции Apple"
+        - person_id: "umputun"
+          confidence: 0.3
+          reason: "Umputun отвечает сразу после"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+        reason: "Слишком короткая реплика для voice comparison"
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 3
+    replies_count: 3
+    pattern: scattered
+    first_appearance_sec: 4298.7
+
+    analysis:
+      is_error: true
+      error_reason: |
+        3 коротких изолированных реплики (0.06-2.1 сек) в разных частях эпизода:
+        - 4298.7s: "Это британские ученые?" (2.1 сек)
+        - 6513.27s: "Угу." (0.06 сек)
+        - 7258.67s: "Хороший докладчик." (1.18 сек)
+
+        Короткие разрозненные реплики типичны для ошибок diarization.
+        Скорее всего это ошибочно вычлененные реплики одного из ведущих.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Первая реплика похожа на уточняющий вопрос от Ксюши"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Может быть Марина"
+        - person_id: "bobuk"
+          confidence: 0.2
+          reason: "Bobuk отвечает 'В смысле?' после первой реплики"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+        reason: "Слишком короткие реплики для voice comparison"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "SPEAKER_01"
+      issue: |
+        SPEAKER_01 с высокой вероятностью является Ksenks (Ксюшей),
+        которая упомянута в представлении. Рекомендуется переименовать.
+    - speaker: "Marin_k_a"
+      issue: |
+        Марина (Marin_k_a) участвует в эпизоде, но не была представлена
+        в начале (Umputun сказал только "Ксюша и Бобук"). Возможно:
+        1) Умпутун не упомянул её отдельно
+        2) Или Marin_k_a это на самом деле кто-то другой
+        Нужна ручная проверка аудио.
+    - speaker: "SPEAKER_01"
+      issue: |
+        Аномалия: в 3046.26s SPEAKER_01 говорит "Ты меня прости, Ксюша" -
+        это противоречит идентификации SPEAKER_01 как Ksenks.
+        Вероятно, эта конкретная реплика ошибочно приписана SPEAKER_01
+        и на самом деле принадлежит Марине (Marin_k_a).
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 391
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      SPEAKER_01 отвечает на обращения "Ксюша" от Umputun.
+      Umputun в начале представляет "Ксюша и Бобук".
+      417 реплик соответствуют объёму со-ведущего.
+
+      ВНИМАНИЕ: требуется ручная проверка реплики 3046.26s
+      ("Ты меня прости, Ксюша") - она может принадлежать Marin_k_a.
+
+# Дополнительные заметки для ручной проверки
+manual_review_notes: |
+  1. Проверить аудио в начале эпизода - действительно ли участвует Марина
+     или это ошибка разметки (и Marin_k_a на самом деле кто-то другой).
+
+  2. Проверить реплику 3046.26s "Ты меня прости, Ксюша" - определить
+     голос говорящего (вероятно это Marin_k_a, а не SPEAKER_01/Ksenks).
+
+  3. Подтвердить идентификацию SPEAKER_01 = Ksenks прослушиванием
+     длинного сегмента (например, 271.7s - ответ на "Ксюша, расскажи").

--- a/validation/episodes/0300-0399/0392.yaml
+++ b/validation/episodes/0300-0399/0392.yaml
@@ -1,0 +1,176 @@
+episode: 392
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_present: 2  # Алексей (SPEAKER_04) и Андрей (SPEAKER_01)
+  total_duration_sec: 6533  # ~109 минут (1162+769 реплик ведущих + гости)
+  notes: "Выпуск 392 в сокращённом составе — только Umputun и Bobuk + гости из чата"
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 107
+    replies_count: 35
+    first_appearance_sec: 2810.52
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: null  # Не в people.yaml, просто "Алексей" из чата
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. При подключении представился: "Алексей" (2810.52s)
+        2. Umputun приветствует: "Алексей, здравствуй" (2815.96s)
+        3. Umputun обращается по имени: "Алексей, спасибо, что зовёшь нам гостей" (3635.96s)
+        4. Обсуждает Ruby, Redmine, Octopress — эксперт в Ruby
+
+      guest_name: "Алексей"
+      guest_context: "Гость из чата, эксперт по Ruby, приглашал других гостей (Олега)"
+
+      possible_matches: []  # Недостаточно информации для точной идентификации
+
+      voice_task:
+        needed: true
+        reason: "Требуется сопоставление голоса для точной идентификации"
+        reference_segment:
+          stime: 2946.81
+          etime: 2960.7
+          text: "Просто я понимаю, что в Ruby действительно там система зависимости очень своеобразная, и ситуация, когда кто-то ломает зависимость, это бывает. И если сравнивать с Java, там как бы не компилируется, нельзя сделать один пакет и закинуть, поэтому да, есть такая проблема."
+          duration_sec: 13.89
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 135
+    replies_count: 34
+    first_appearance_sec: 4389.53
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация
+      identified_as: null  # Не в people.yaml, "Андрей" из чата
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        1. Umputun представляет: "Я включил к нам Андрея в разговор" (4382.12s)
+        2. Обращения по имени: "Андрей, ты за или против?" (4382.12s)
+        3. "Вот это, если ты не потестируешь, ты будешь, Андрей, жить спокойно" (4788.29s)
+        4. "Короче, Андрей, ты что-то темнишь" (4887.69s)
+        5. "Андрей, спасибо, что пришёл" (4964.62s)
+        6. Обсуждает интеграционные vs юнит-тесты — разработчик
+
+      guest_name: "Андрей"
+      guest_context: "Гость из чата, разработчик, обсуждал тестирование"
+
+      possible_matches: []  # Недостаточно информации
+
+      voice_task:
+        needed: true
+        reason: "Требуется сопоставление голоса для точной идентификации"
+        reference_segment:
+          stime: 4899.21
+          etime: 4920.99
+          text: "Проблема во всех этих методологиях, что они говорят, ребята, тестируйте, и будет всем счастье. Но они не говорят, в каких случаях что тестировать. И это самое важное, мне кажется. Потому что тесты, применимость у них разная. И саппортабилити тоже там участвует."
+          duration_sec: 21.78
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 21
+    replies_count: 3
+    first_appearance_sec: 4509.92
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибочно созданный спикер. Реплики принадлежат SPEAKER_01 (Андрею)"
+
+      # Контекстуальное доказательство
+      evidence: |
+        1. Все 3 реплики находятся внутри блока обсуждения тестирования с Андреем
+        2. Первая реплика (4509.92s) продолжает мысль SPEAKER_01 о кусках системы (4506.40-4509.08s)
+        3. Реплики 2-3 (4644.35-4659.60s) — ответ на Umputun о юнит-тестах
+        4. Сразу после них SPEAKER_01 продолжает говорить (4662.09s)
+        5. Тема та же: тестирование, бизнес-логика, синхронизация
+        6. Эльдар Муртазин не участвовал в этом выпуске
+
+      voice_task:
+        needed: false
+        reason: "Очевидная ошибка атрибуции — реплики принадлежат Андрею"
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 0.22
+    replies_count: 1
+    first_appearance_sec: 2462.39
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Артефакт распознавания — односложное междометие 'Ох...' длительностью 0.22 сек"
+
+      evidence: |
+        1. Единственная реплика: "Ох..." (2462.39-2462.61s)
+        2. Длительность 0.22 секунды
+        3. Типичный паттерн ошибки: случайное междометие
+
+      voice_task:
+        needed: false
+        reason: "Очевидный артефакт, слишком короткий для анализа"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues: []
+  notes: |
+    - Umputun и Bobuk — основные ведущие, представлены в начале
+    - SPEAKER_04 (Алексей) — явно представлен при подключении (~2810s)
+    - SPEAKER_01 (Андрей) — явно представлен Umputun'ом (~4382s)
+    - Упоминается второй Алексей, которого не удалось подключить из-за Skype
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 392
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Guest_Alexey_392"
+    confidence: high
+    reason: "Гость представился как Алексей, подтверждено ведущим"
+
+  - type: rename
+    episode: 392
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Guest_Andrey_392"
+    confidence: high
+    reason: "Гость представлен Umputun'ом как Андрей"
+
+  - type: rename
+    episode: 392
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    to_speaker: "Guest_Andrey_392"
+    confidence: high
+    reason: "Ошибочная атрибуция — это тот же Андрей (SPEAKER_01), продолжение диалога о тестах"
+
+  - type: delete
+    episode: 392
+    speaker: "SPEAKER_05"
+    confidence: high
+    reason: "Артефакт — междометие 0.22 сек, не информативно"
+
+# Примечания
+notes: |
+  Эпизод 392 (17 мая 2014) — сокращённый состав: только Umputun и Bobuk.
+  Два гостя из чата:
+  1. Алексей (SPEAKER_04) — эксперт по Ruby, ~46 мин в эфире, обсуждал Redmine, Octopress, зависимости
+  2. Андрей (SPEAKER_01) — разработчик, ~9 мин в эфире, обсуждал интеграционные vs юнит-тесты
+
+  SPEAKER_MISATTRIBUTED_ELDAR — ошибочно созданный спикер, реплики принадлежат Андрею.
+  SPEAKER_05 — артефакт распознавания.
+
+  Для точной идентификации Алексея и Андрея требуется voice comparison или информация
+  из архивов чата того периода.

--- a/validation/episodes/0300-0399/0393.yaml
+++ b/validation/episodes/0300-0399/0393.yaml
@@ -1,0 +1,246 @@
+episode: 393
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray]
+  guests_present: [Marin_k_a]
+  total_duration_sec: 7500  # ~2 часа
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1434
+    replies_count: 345
+    pattern: consecutive
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "В начале эпизода (74s) Umputun говорит 'Поэтому я тебя, Ксюша, не назвал Маринкой' - подтверждает что это Марина, бывшая ведущая"
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_08"
+    total_duration_sec: 382
+    replies_count: 61
+    pattern: consecutive
+    analysis:
+      is_error: false
+      identified_as: null
+      identification_method: "introduction"
+      confidence: high
+      evidence: "Umputun приветствует гостя по имени: 'Здравствуй, Максим' (3427s) и 'Так, Максим' (3439s). Гость представляется как пользователь из Курска, обсуждает поисковик 'Спутник'"
+      possible_matches:
+        - person_id: "guest_maxim_kursk"
+          confidence: 0.9
+          reason: "Явное представление по имени, из Курска, обсуждает Спутник"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 3472.63
+          etime: 3489.78
+          text: "Безусловно, я не с точки зрения программирования скажу, а просто с точки зрения пользователя обычного. То есть понятно, что я сейчас, естественно, пользуюсь гуглом, например, и особо не возникает желания взять, открыть спутник, что-то поискать."
+      notes: "Нужно добавить в people.yaml как нового гостя Максим из Курска"
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 168
+    replies_count: 34
+    pattern: consecutive
+    analysis:
+      is_error: false
+      identified_as: null
+      identification_method: "introduction"
+      confidence: high
+      evidence: "Umputun приветствует: 'Вот, Дмитрий, здравствуй' (1390s) и говорит 'Ты у нас защитник поверхностей' (1395s). Гость обсуждает Microsoft Surface и технологии снижения лага тач-экранов"
+      possible_matches:
+        - person_id: "guest_dmitry_surface"
+          confidence: 0.9
+          reason: "Явное представление по имени, эксперт по Surface"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1497.14
+          etime: 1528.70
+          text: "Когда используете этот новый экран, технологию, то там линия, она как будто к пальцу привязана. Это видно вот именно в сравнении, когда... когда этим начинаешь пользоваться. И то, что они приделали к Surface перо с степенями чувствительности и таким отсутствием лага, это будет очень круто именно при использовании приевого ввода."
+      notes: "Нужно добавить в people.yaml как нового гостя Дмитрий. Вероятно, он же отмечен как EldarMurtazin и SPEAKER_MISATTRIBUTED_PETR"
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 83
+    replies_count: 13
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: "Ошибочная атрибуция - это не Эльдар Муртазин. Реплики принадлежат гостю Дмитрию (SPEAKER_01), который обсуждает Surface. Эльдар Муртазин - известный мобильный аналитик с узнаваемым голосом и стилем, эти реплики не соответствуют его манере"
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "guest_dmitry_surface"
+          confidence: 0.85
+          reason: "Реплики продолжают мысль SPEAKER_01 (Дмитрия) о Surface и тач-экранах"
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1410.97
+          etime: 1432.81
+          text: "Вот, скажу, ну, начну с того, что около года назад от Microsoft Research было видео, в котором они рассказывали про то, что они... Они разработали некую технологию, которая помогает им сделать практически нулевой отклик при работе с тач-экраном."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 19
+    replies_count: 2
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: "Ранее ошибочно присвоено PetrDidenko и отменено (MISATTRIBUTED). Реплики являются частью диалога гостя Дмитрия о лаге тач-экранов"
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "guest_dmitry_surface"
+          confidence: 0.85
+          reason: "Реплики о лаге iPad при рисовании - продолжение темы Дмитрия"
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 5
+    replies_count: 2
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: "Две короткие реплики (1252s и 4062s) в разных частях эпизода - вероятно ошибки распознавания разных спикеров"
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.5
+          reason: "Реплика 'То есть, можно рядом пробовать' (1252s) между репликами Gray"
+        - person_id: "umputun"
+          confidence: 0.5
+          reason: "Реплика 'Ну, это не ежедневный запрос' (4062s) может быть от любого ведущего"
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 5
+    replies_count: 4
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: "4 короткие реплики (<2 сек каждая) разбросаны по всему эпизоду: 'Ну, я не знаю', 'Да, понимаю', 'Мне кажется, да', 'Две минуты?' - типичные ошибки распознавания коротких фраз"
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.6
+          reason: "Могут быть репликами Марины, разбросанными из-за ошибок распознавания"
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_06"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: "Одна реплика 'Я вот удивительно согласна' (961s) - женский род указывает на Marin_k_a"
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: medium
+      evidence: "Грамматический род 'согласна' указывает на женщину, в эпизоде только одна женщина - Марина"
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.85
+          reason: "Единственная женщина в эпизоде, грамматический род совпадает"
+      voice_task:
+        needed: false
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "EldarMurtazin"
+      issue: "Ошибочная атрибуция - реплики принадлежат гостю Дмитрию, не Эльдару Муртазину"
+    - speaker: "SPEAKER_01"
+      issue: "Гость Дмитрий идентифицирован, но его реплики разбиты на несколько спикеров (SPEAKER_01, EldarMurtazin, SPEAKER_MISATTRIBUTED_PETR)"
+    - speaker: "SPEAKER_08"
+      issue: "Гость Максим из Курска идентифицирован, но отсутствует в people.yaml"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 393
+    from_speaker: "SPEAKER_06"
+    to_speaker: "Marin_k_a"
+    confidence: medium
+    reason: "Грамматический род 'согласна' указывает на единственную женщину в эпизоде"
+
+  - type: rename
+    episode: 393
+    from_speaker: "EldarMurtazin"
+    to_speaker: "Guest_Dmitry"
+    confidence: high
+    reason: "Ошибочная атрибуция - это гость Дмитрий, представленный Umputun'ом в 1390s"
+
+  - type: rename
+    episode: 393
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Guest_Dmitry"
+    confidence: high
+    reason: "Гость представлен как Дмитрий, 'защитник поверхностей'"
+
+  - type: rename
+    episode: 393
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    to_speaker: "Guest_Dmitry"
+    confidence: high
+    reason: "Реплики продолжают тему Дмитрия о лаге тач-экранов"
+
+  - type: rename
+    episode: 393
+    from_speaker: "SPEAKER_08"
+    to_speaker: "Guest_Maxim"
+    confidence: high
+    reason: "Гость представлен по имени Максим, из Курска"
+
+# Необходимые дополнения в people.yaml
+people_yaml_additions:
+  - id: "guest_dmitry_surface"
+    canonical_name: "Guest_Dmitry"
+    aliases: []
+    real_name: "Дмитрий"
+    info: "Гость в выпуске 393, эксперт по Microsoft Surface"
+
+  - id: "guest_maxim_kursk"
+    canonical_name: "Guest_Maxim"
+    aliases: []
+    real_name: "Максим"
+    info: "Гость в выпуске 393, из Курска, обсуждал поисковик Спутник"
+
+# Комментарии
+notes: |
+  Эпизод 393 от 24 мая 2013 года.
+
+  Ведущие: Umputun и Gray. Bobuk отсутствует (упоминается "где блуждает Бобук?").
+
+  Постоянный гость: Marin_k_a (Марина, бывшая ведущая) - 345 реплик.
+
+  Приглашённые гости:
+  1. Дмитрий - "защитник поверхностей" (Surface), появляется ~1390s.
+     Его реплики ошибочно разбиты на SPEAKER_01, EldarMurtazin и SPEAKER_MISATTRIBUTED_PETR.
+
+  2. Максим из Курска - появляется ~3427s для обсуждения поисковика "Спутник".
+     Отмечен как SPEAKER_08.
+
+  SPEAKER_03, SPEAKER_04, SPEAKER_06 - короткие ошибочные атрибуции, вероятно реплики ведущих или Марины.

--- a/validation/episodes/0300-0399/0394.yaml
+++ b/validation/episodes/0300-0399/0394.yaml
@@ -1,0 +1,270 @@
+episode: 394
+status: needs_review
+analyzed_at: "2026-01-25T12:00:00Z"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk, Gray]
+  hosts_mentioned_but_missing: [Ksenks]  # Упоминается как "Ксюша", но нет как спикер
+  guests_identified: [Влад]  # Гость по Skype, эксперт по TrueCrypt
+  total_duration_sec: 8500  # примерно 2.3 часа
+
+# Ключевая проблема: Marin_k_a - это на самом деле Ksenks!
+critical_issues:
+  - issue: "Marin_k_a в этом эпизоде - это Ksenks (Ксюша)"
+    evidence:
+      - "В начале Umputun говорит: 'Ты да я, да Грей, да Ксюша' (время 126.15s) - упоминает только 4 человека"
+      - "Umputun обращается: 'Ксюша, расскажи нам вкратце историю вопроса' (время 396.46s)"
+      - "Сразу после отвечает Marin_k_a (время 400.37s) - явно отвечая на обращение к Ксюше"
+      - "Имя 'Марина' или 'Marina' НЕ упоминается в транскрипте ни разу"
+      - "Слово 'Ксюша' упоминается 15+ раз как обращение к присутствующему участнику"
+    confidence: high
+    suggested_action: "Переименовать Marin_k_a -> Ksenks для эпизода 394"
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1070
+    replies_count: 202
+    pattern: consecutive
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибочная маркировка. Это Ksenks (Ксюша), не Марина."
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: "Umputun обращается 'Ксюша, расскажи нам...' в 396.46s, отвечает Marin_k_a в 400.37s"
+
+      possible_matches: []
+
+      voice_task:
+        needed: false  # Контекст однозначен
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 688
+    replies_count: 114
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+      identified_as: null  # Новый гость "Влад"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Bobuk в 638.54s: "А, дорогой Влад, а что ты вздыхаешь?"
+        Bobuk в 640.26s: "У тебя же есть скайп, ты очень легко можешь присоединиться к нашей беседе"
+        Bobuk в 648.55s: "это будет комментарий действительно опытного специалиста"
+        Bobuk в 726.1s: "Дорогой Влад, блин, в скайп"
+        Umputun в 740.86s: "Да, Володь, Умпутун в скайпе Умпутун"
+        SPEAKER_05 начинает в 986.68s с экспертным рассказом о TrueCrypt
+
+      possible_matches:
+        - person_id: "vlad_new_guest"
+          confidence: 0.95
+          reason: "Гость по имени Влад (Володя), эксперт по криптографии/TrueCrypt"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1000.43
+          etime: 1014.24
+          text: "Вы, наверное, знаете, и я думаю, здесь много раз обсуждалось, что в некоторых странах факт отказа от выдачи ключей соответствующим органам, если вдруг ты оказываешься перед судом,"
+        notes: "Длинный экспертный монолог, хорошее качество для идентификации"
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 505
+    replies_count: 246
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Вероятно также Ksenks - реплики перемежаются с Marin_k_a в одном диалоге"
+      identified_as: "ksenks"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        SPEAKER_02 и Marin_k_a участвуют в одном диалоге о TrueCrypt
+        Например: SPEAKER_02 в 411.86s и Marin_k_a в 429.27s обсуждают одну тему
+        Обе говорят про FileVault/шифрование женским голосом
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.75
+          reason: "Участвует в диалоге как Ксюша, голос похож на Marin_k_a"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 417.74
+          etime: 427.99
+          text: "Но в Маке это может быть системная возможность, то есть ты в References можешь галочку в нужном месте поставить, а TrueCrypt это приложение, я так понимаю, для Windows."
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 28
+    replies_count: 15
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Короткие реплики, вероятно ошибка распознавания одного из ведущих"
+      identified_as: null
+      identification_method: null
+      confidence: low
+      evidence: |
+        Примеры реплик: "Как неожиданно, да." (745s), "Представляешь?" (2865s)
+        Слишком короткие для идентификации по контексту
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Короткие реактивные фразы, возможно Ксюша"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Мог быть Бобук с плохим распознаванием"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2865.01
+          etime: 2868.77
+          text: "Представляешь? Да, и руки после этого не мою."
+        notes: "Лучший сегмент из имеющихся, но все равно короткий"
+
+  - speaker: "SPEAKER_07"
+    total_duration_sec: 0
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Одна реплика 'Отлично' (0.4 сек) - явная ошибка распознавания"
+      identified_as: null
+      identification_method: null
+      confidence: high
+      evidence: "Единственная реплика: 'Отлично.' в 2899.04s длительностью 0.4 сек"
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        notes: "Слишком короткая реплика для идентификации"
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 8
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Помечено как 'misattributed' - ранее ошибочно присвоено Эльдару"
+      identified_as: null
+      identification_method: null
+      confidence: low
+      evidence: |
+        3 короткие реплики в разных местах:
+        - 1405.35s: "Да, ну можно же было придумать какую-нибудь причину, нормальная причина."
+        - 2776.64s: "Ну, короче, оно примерно так."
+        - 8260.26s: "Нет, что-то."
+
+      possible_matches:
+        - person_id: "speaker_05_vlad"
+          confidence: 0.5
+          reason: "Первая реплика в контексте обсуждения TrueCrypt, где говорит Влад"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 1405.35
+          etime: 1408.79
+          text: "Да, ну можно же было придумать какую-нибудь причину, нормальная причина."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 4
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Помечено как 'misattributed' - ранее ошибочно присвоено Лаваль"
+      identified_as: null
+      identification_method: null
+      confidence: low
+      evidence: |
+        2 короткие реплики:
+        - 6906.76s: "Просто все думают, ну что это он такой странный."
+        - 8311.91s: "То есть, не совсем что новый."
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.4
+          reason: "Между репликами Marin_k_a, возможно тот же спикер"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6906.76
+          etime: 6909.68
+          text: "Просто все думают, ну что это он такой странный."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Gray"
+      issue: "Упоминается в начале ('да Грей'), но только 2 реплики за весь выпуск (5299.57s и 8217.67s). Либо подключился позже и мало говорил, либо часть реплик неправильно атрибутирована."
+
+    - speaker: "Ksenks"
+      issue: "Упоминается как 'Ксюша' многократно, но как спикер отсутствует. Вместо этого есть Marin_k_a и SPEAKER_02 - вероятно это и есть Ксюша."
+
+    - speaker: "SPEAKER_05"
+      issue: "Гость Влад - не представлен формально в начале, но приглашен в чате (~640s). Нужно добавить в справочник people.yaml."
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 394
+    from_speaker: "Marin_k_a"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun обращается "Ксюша, расскажи нам..." в 396.46s,
+      отвечает Marin_k_a в 400.37s.
+      Имя "Марина" не упоминается в транскрипте.
+      В начале перечислены только Umputun, Bobuk, Gray, Ксюша.
+
+  - type: rename
+    episode: 394
+    from_speaker: "SPEAKER_02"
+    to_speaker: "Ksenks"
+    confidence: medium
+    reason: |
+      SPEAKER_02 участвует в том же диалоге что и Marin_k_a,
+      реплики перемежаются. Вероятно это тот же человек (Ксюша)
+      с ошибкой распознавания голоса.
+
+  - type: add_guest
+    episode: 394
+    speaker: "SPEAKER_05"
+    guest_name: "Vlad"
+    confidence: high
+    reason: |
+      Bobuk обращается "дорогой Влад" в 638.54s,
+      приглашает в Skype для экспертного комментария.
+      SPEAKER_05 начинает говорить в 986.68s с экспертизой по TrueCrypt.
+      Нужно добавить в people.yaml как нового гостя.
+
+  - type: delete_or_merge
+    episode: 394
+    speaker: "SPEAKER_07"
+    confidence: high
+    reason: "Одна реплика 'Отлично' (0.4 сек) - явная ошибка распознавания, можно удалить или смержить с соседним спикером"
+
+# Метаданные для дальнейшей обработки
+audio_url: null  # Нужно взять из data/394/394_desc.json если есть
+needs_manual_review:
+  - "Подтвердить, что Marin_k_a = Ksenks голосовым сравнением"
+  - "Проверить, что SPEAKER_02 = Ksenks"
+  - "Идентифицировать гостя Влада (SPEAKER_05) - найти полное имя"
+  - "Разобраться с SPEAKER_MISATTRIBUTED_ELDAR и SPEAKER_MISATTRIBUTED_LAVALE"

--- a/validation/episodes/0300-0399/0395.yaml
+++ b/validation/episodes/0300-0399/0395.yaml
@@ -1,0 +1,298 @@
+episode: 395
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Bobuk, Gray]
+  guests_present: [Marin_k_a, Ksenks, Swan]
+  total_duration_sec: 7964
+  notes: |
+    Umputun НЕ присутствует в этом эпизоде. В начале явно говорят:
+    "ужасная бородатая половина" (Bobuk + Gray) и "прекрасная половина" (Ksenks + Marin_k_a).
+    Сван сидит рядом с Bobuk и комментирует через его микрофон.
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 896
+    replies_count: 356
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        В 185-188s Gray спрашивает "Ксюша, ты тут ли?" и SPEAKER_03 отвечает
+        "Да, я тут. Всем привет." Также SPEAKER_03 говорит "Но мы-то с Грэм далеко"
+        (335s), указывая что она из другого места чем Bobuk и Сван.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1647
+    replies_count: 258
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        Уже промаркирована как Marin_k_a. Это Марина (бывшая ведущая согласно people.yaml).
+        Активно участвует в техническом обсуждении iOS/Swift наравне с Ksenks.
+        Bobuk говорит "ты сегодня не одна у нас в нашей прекрасной половине" —
+        подразумевая двух женщин-участниц (Ksenks и Marin_k_a).
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_06"
+    total_duration_sec: 112
+    replies_count: 45
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "swan"
+          confidence: 0.9
+          reason: |
+            Сван упоминается многократно как сидящий рядом с Bobuk.
+            SPEAKER_06 говорит характерные для Свана фразы: "Apple уже не тот",
+            "Ой, Сережа, перестань" (обращение к Gray), "Ксюша, не позорище ли..."
+            Bobuk в 271s говорит: "Сван сидит рядом со мной... его периодически будет слышно"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2547.8
+          etime: 2559.3
+          text: "Нет, относительно Samsung они, конечно, молодцы, да. Но нельзя сравнивать это с Samsung в этом месте. Но столько лет делать таким невыносимым..."
+
+  - speaker: "SPEAKER_08"
+    total_duration_sec: 13
+    replies_count: 7
+    pattern: scattered
+
+    analysis:
+      is_error: false
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "swan"
+          confidence: 0.7
+          reason: |
+            Короткие реплики через микрофон Bobuk'а.
+            "Ура, и ты даже через правильный микрофон" (189s) — приветствует Ksenks.
+            Может быть Сван или кто-то рядом с Bobuk.
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 2758.6
+          etime: 2761.0
+          text: "Что значит чистый? Это если ты, пока ты до удобств не дошла."
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 9
+    replies_count: 7
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Короткие случайные реплики: "Что договорились", "Окей", "Почему?".
+        Скорее всего ошибки сегментации — реплики других спикеров.
+
+      possible_matches:
+        - person_id: "swan"
+          confidence: 0.5
+          reason: "Возможно реплики Свана через микрофон Bobuk'а"
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 6
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Всего 3 реплики за 6 секунд в одном месте (3913-3920s).
+        "Из симбокса через файловую систему" — технический комментарий.
+        Скорее всего ошибка сегментации одного из основных спикеров.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 3
+    replies_count: 3
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Всего 3 короткие реплики: "25-й" (369s), "Одинаково холодно, да?" (381s),
+        "Нет, я не кричу вообще сегодня" (3319s). Ошибки сегментации.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 7
+    replies_count: 2
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Маркер отменённой ошибочной атрибуции. 2 реплики в контексте
+        обсуждения презентации Apple — не имеют отношения к Lavale.
+        Скорее всего это Ksenks или Marin_k_a.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 2
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Маркер отменённой ошибочной атрибуции. 1 реплика "У вас в стране так не принято"
+        в контексте обсуждения сексизма. Не имеет отношения к Эльдару Муртазину.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+
+  - speaker: "Umputun"
+    total_duration_sec: 7
+    replies_count: 4
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Umputun НЕ присутствует в эпизоде 395. В начале эпизода явно говорят
+        только о двух ведущих (Bobuk + Gray) и двух гостях (Ksenks + Marin_k_a).
+        4 короткие реплики (макс. 2.4 сек каждая) — ошибочная атрибуция.
+        Это скорее всего Сван, говорящий через микрофон Bobuk'а.
+
+      possible_matches:
+        - person_id: "swan"
+          confidence: 0.8
+          reason: "Короткие комментарии рядом с Bobuk — типичный паттерн для Свана в этом эпизоде"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 7868.0
+          etime: 7870.4
+          text: "Ну, собственно, там, где платить просят."
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: false
+  issues:
+    - speaker: "Umputun"
+      issue: |
+        Umputun НЕ присутствует в этом эпизоде, но 4 реплики помечены его именем.
+        В начале эпизода представляют только: Bobuk, Gray, Ksenks (Ксюша),
+        и упоминают Marin_k_a. Сван сидит рядом с Bobuk как гость, не ведущий.
+
+    - speaker: "Swan"
+      issue: |
+        Сван активно комментирует весь эпизод (упоминается ~20 раз),
+        но нет консистентной маркировки его реплик. SPEAKER_06 — наиболее вероятно Сван.
+
+    - speaker: "SPEAKER_03"
+      issue: |
+        Нужно переименовать в Ksenks — идентификация подтверждена с высокой уверенностью.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 395
+    from_speaker: "SPEAKER_03"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Прямое представление: Gray спрашивает "Ксюша, ты тут ли?" и SPEAKER_03 отвечает
+      "Да, я тут. Всем привет." Также SPEAKER_03 говорит "мы-то с Грэм далеко".
+
+  - type: rename
+    episode: 395
+    from_speaker: "SPEAKER_06"
+    to_speaker: "Swan"
+    confidence: medium
+    reason: |
+      Контекстуальный анализ: Сван сидит рядом с Bobuk (подтверждено в 271s),
+      SPEAKER_06 делает характерные для Свана комментарии про Apple/iOS,
+      обращается к ведущим по имени. Требуется voice comparison для подтверждения.
+
+  - type: delete
+    episode: 395
+    speaker: "Umputun"
+    confidence: high
+    reason: |
+      Umputun НЕ участвует в эпизоде 395. 4 реплики — ошибочная атрибуция,
+      скорее всего это Сван через микрофон Bobuk'а.
+
+  - type: merge
+    episode: 395
+    from_speakers: ["SPEAKER_08", "SPEAKER_01", "SPEAKER_02"]
+    to_speaker: "Swan"
+    confidence: low
+    reason: |
+      Все эти спикеры — короткие разрозненные реплики, вероятно Сван через микрофон.
+      Требуется voice comparison для подтверждения.
+
+  - type: delete
+    episode: 395
+    speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    confidence: high
+    reason: "Маркер отменённой ошибочной атрибуции. Требуется переприсвоение к Ksenks или Marin_k_a."
+
+  - type: delete
+    episode: 395
+    speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    confidence: high
+    reason: "Маркер отменённой ошибочной атрибуции. Требуется переприсвоение."
+
+# Дополнительные заметки
+notes: |
+  Эпизод 395 записан без Umputun. Состав ведущих: Bobuk + Gray.
+  Гости: Ksenks (Ксюша) и Marin_k_a (Марина).
+  Сван присутствует физически рядом с Bobuk и комментирует через его микрофон.
+
+  Основная проблема: Сван не имеет консистентной маркировки — его реплики
+  разбросаны по SPEAKER_06, SPEAKER_08, SPEAKER_01, SPEAKER_02 и даже Umputun.
+
+  Для точной атрибуции реплик Свана требуется voice comparison с известными
+  записями его голоса.
+
+  Swan отсутствует в people.yaml — требуется добавление.

--- a/validation/episodes/0300-0399/0396.yaml
+++ b/validation/episodes/0300-0399/0396.yaml
@@ -1,0 +1,200 @@
+episode: 396
+status: has_tasks
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Bobuk, Gray]
+  hosts_absent: [Umputun, Ksenks, Alek.sys]
+  total_duration_sec: 8961
+  notes: "Gray ведет эпизод, Umputun в отъезде (упоминается что гоняет мечехвостов)"
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 1310
+    replies_count: 428
+    first_appearance_sec: 36
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        1. Женский род глаголов: "обклеила", "гордилась", "хотела", "согласна", "удивилась"
+        2. Реплики чередуются с Marin_k_a без паузы (84.8s Marin_k_a -> 87.0s SPEAKER_04)
+        3. Тематически одинаковый контент - воспоминания о Тетрисе, девайсах, общие темы
+        4. Суммарно SPEAKER_04 + Marin_k_a = 597 реплик, 2325 сек - типичный объём для активного участника
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+        reason: "Идентификация высокой уверенности по грамматике и контексту"
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 1015
+    replies_count: 169
+    first_appearance_sec: 85
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+
+      identified_as: "marin_k_a"
+      identification_method: "known_speaker"
+      confidence: high
+      evidence: "Marin_k_a - известный спикер (Марина, бывшая ведущая) в people.yaml"
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    total_duration_sec: 18
+    replies_count: 8
+    first_appearance_sec: 669
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Эльдар Муртазин не участвует в этом эпизоде (ведущие - только Bobuk и Gray + гость Marin_k_a).
+        Реплики вклиниваются между Gray и Bobuk без логического перехода.
+        Пример: Gray "Есть совсем попсовая тема" -> MISATTRIBUTED_ELDAR "Именно про попсу" -> Gray "Иногда про рок"
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "gray"
+          confidence: 0.6
+          reason: "Реплики логически продолжают речь Gray, между его фразами"
+        - person_id: "bobuk"
+          confidence: 0.3
+          reason: "Альтернативный вариант - могут быть короткие вставки Bobuk"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 671.67
+          etime: 675.89
+          text: "Это про то, что Амазон запустил онлайн-стриминг."
+        compare_with: ["Gray", "Bobuk"]
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 15
+    replies_count: 3
+    first_appearance_sec: 6243
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Lavale не участвует в этом эпизоде.
+        Все 3 реплики появляются между репликами Marin_k_a в одном разговоре про Evernote/TestFlight.
+        Тематически и контекстуально это продолжение речи Marin_k_a.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.8
+          reason: "Реплики между Marin_k_a, продолжают её мысль об Evernote и девайсах"
+        - person_id: "bobuk"
+          confidence: 0.15
+          reason: "Bobuk мог вставить комментарий, но контекст указывает на Marin_k_a"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 6622.76
+          etime: 6630.63
+          text: "Во-первых, тысяча не устройств, а конкретных пользователей, у которых может быть не один девайс, а несколько."
+        compare_with: ["Marin_k_a", "Bobuk"]
+
+  - speaker: "SPEAKER_03"
+    total_duration_sec: 2
+    replies_count: 2
+    first_appearance_sec: 2226
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Только 2 коротких реплики-междометия ("Непривязанное государство, да." и "Вау.").
+        Типичные ошибки распознавания коротких реакций.
+        "Вау" появляется сразу после рассказа Bobuk и он же продолжает "Вау, так не бывает."
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "bobuk"
+          confidence: 0.5
+          reason: "Первая реплика в контексте разговора Bobuk о биткоине"
+        - person_id: "gray"
+          confidence: 0.3
+          reason: "Gray мог вставить короткую реплику"
+        - person_id: "marin_k_a"
+          confidence: 0.2
+          reason: "Marin_k_a как активный участник могла сказать 'Вау'"
+
+      voice_task:
+        needed: false
+        reason: "Слишком короткие реплики (<2 сек) для надёжного voice comparison"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes: |
+    Gray начинает эпизод с приветствия (3s).
+    Bobuk подхватывает (15s), упоминает отсутствие Umputun.
+    Marin_k_a/SPEAKER_04 присоединяется с 36s - не представлена явно,
+    но по голосам узнаваема (Gray говорит "по голосам понятно" в 64s).
+  issues:
+    - speaker: "SPEAKER_04"
+      issue: "Это Marin_k_a, требуется объединение под одним спикером"
+    - speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+      issue: "Ошибочная атрибуция, Эльдар не участвует в эпизоде"
+    - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+      issue: "Ошибочная атрибуция, Lavale не участвует в эпизоде"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 396
+    from_speaker: "SPEAKER_04"
+    to_speaker: "Marin_k_a"
+    confidence: high
+    reason: "Женский род, чередование реплик с Marin_k_a, тематическая консистентность"
+
+  - type: rename
+    episode: 396
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Marin_k_a"
+    confidence: medium
+    reason: "Реплики между Marin_k_a, продолжают её разговор. Требует voice verification."
+
+  - type: voice_verification_needed
+    episode: 396
+    from_speaker: "SPEAKER_MISATTRIBUTED_ELDAR"
+    candidates: ["Gray", "Bobuk"]
+    confidence: medium
+    reason: "Короткие реплики между ведущими, нужно определить чей голос"
+
+  - type: error_likely
+    episode: 396
+    speaker: "SPEAKER_03"
+    reason: "2 коротких междометия, слишком мало данных для идентификации"

--- a/validation/episodes/0300-0399/0397.yaml
+++ b/validation/episodes/0300-0399/0397.yaml
@@ -1,0 +1,178 @@
+episode: 397
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Gray, Bobuk]
+  guests_present: [Дмитрий (SPEAKER_04), Руслан (SPEAKER_06)]
+  total_duration_sec: 7009  # приблизительно по последней реплике
+
+# Критические проблемы
+critical_issues:
+  - issue: "EldarMurtazin ошибочно присвоен"
+    evidence:
+      - "2515.95s: Umputun говорит 'Жалко нет Эльдара, который бы наверняка разбил бы всю эту идею'"
+      - "3383.07s: Umputun говорит 'Мое такое сугубое мнение, жалко нет Эльдара, он бы нам добавил'"
+    conclusion: "Эльдар Муртазин НЕ участвовал в этом выпуске. Все 24 реплики EldarMurtazin ошибочны."
+    recommended_action: "Переименовать EldarMurtazin -> SPEAKER_04 (Дмитрий)"
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_04"
+    total_duration_sec: 939
+    replies_count: 175
+    pattern: consecutive
+    analysis:
+      is_error: false
+      identified_as: null  # Не зарегистрирован в people.yaml
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        44.19s: Umputun говорит "Это я про тебя, Дмитрий"
+        224.41s: Umputun говорит "молодой наш Дмитрий"
+        288.08s: Umputun говорит "Дмитрий, как молодой, молодым у нас везде дорога"
+      real_name: "Дмитрий"
+      notes: |
+        Представлен как "молодой" гость, "буквально руки со скамейки запасных".
+        Описан как тот, кто "никогда в NBA не играл" (т.е. новичок в подкасте).
+        Активно участвует в технических дискуссиях про Docker, Go, FPGA.
+      possible_matches: []
+      voice_task:
+        needed: false  # Уже идентифицирован по имени
+
+  - speaker: "SPEAKER_06"
+    total_duration_sec: 255
+    replies_count: 59
+    pattern: consecutive
+    analysis:
+      is_error: false
+      identified_as: null  # Не зарегистрирован в people.yaml
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        52.96s: Umputun спрашивает "Руслан, два раза?"
+        54.43s: SPEAKER_06 отвечает "Да, правда, два раза был"
+        64.65s: Umputun говорит "Или отключай, Руслан"
+        1393.7s: SPEAKER_04 говорит "Да, да, я полностью согласен с Русланом"
+      real_name: "Руслан"
+      notes: |
+        Представлен как гость, который уже был на подкасте 2 раза.
+        Umputun отмечает, что его "не отключали досрочно, что редкость".
+        Активно участвует в технических дискуссиях.
+      possible_matches: []
+      voice_task:
+        needed: false  # Уже идентифицирован по имени
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 106
+    replies_count: 24
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: |
+        Эльдар Муртазин НЕ участвовал в выпуске 397.
+        Прямое доказательство: Umputun дважды говорит "жалко нет Эльдара":
+        - 2515.95s: "Жалко нет Эльдара, который бы наверняка разбил бы всю эту идею"
+        - 3383.07s: "жалко нет Эльдара, он бы нам добавил"
+        Все реплики EldarMurtazin являются ошибочной разметкой.
+      likely_real_speaker: "SPEAKER_04"
+      evidence_for_reassignment: |
+        Первая реплика EldarMurtazin (302.46s) идёт сразу после SPEAKER_04 (301.66s)
+        и продолжает ту же тему (Docker, VirtualInf, контейнеризация).
+        Следующая реплика SPEAKER_04 (309.18s) продолжает тот же монолог.
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 10
+    replies_count: 1
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная реплика в 3632.9s: "Наверное, нас скоро ждет следующий этап развития..."
+        Сразу после неё SPEAKER_04 продолжает ту же мысль (3643.35s):
+        "То есть копировать данные, например, на DigitalOcean из Амазона..."
+        Это явно часть одного монолога SPEAKER_04.
+      likely_real_speaker: "SPEAKER_04"
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 3
+    replies_count: 1
+    pattern: scattered
+    analysis:
+      is_error: true
+      error_reason: |
+        Единственная короткая реплика в 1816.61s: "Потому что никто еще в жизни не попользовался"
+        Скорее всего ошибка распознавания - короткая фраза в случайный момент.
+      likely_real_speaker: "unknown"
+      notes: "Недостаточно контекста для определения реального спикера"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  notes: |
+    В начале выпуска (34-67s) Umputun представляет обоих гостей:
+    - Дмитрий: "Это я про тебя, Дмитрий" (44.19s), описан как новичок
+    - Руслан: "Руслан, два раза?" (52.96s), был 2 раза ранее
+    Bobuk отсутствует в начале, появляется позже (421.58s)
+    Ksenks отсутствует ("пропали одновременно и Ксюша, и Бобок")
+  issues:
+    - speaker: "EldarMurtazin"
+      issue: |
+        Эльдар НЕ был представлен и НЕ присутствовал в выпуске.
+        Umputun дважды говорит "жалко нет Эльдара".
+        Все реплики EldarMurtazin - ошибка разметки.
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 397
+    from_speaker: "EldarMurtazin"
+    to_speaker: "SPEAKER_04"
+    confidence: high
+    reason: |
+      Эльдар Муртазин НЕ участвовал в выпуске (доказано фразами Umputun).
+      Реплики по контексту принадлежат SPEAKER_04 (Дмитрий).
+
+  - type: rename
+    episode: 397
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    to_speaker: "SPEAKER_04"
+    confidence: high
+    reason: |
+      Единственная реплика является частью монолога SPEAKER_04.
+      Контекст и содержание совпадают.
+
+  - type: delete_or_merge
+    episode: 397
+    speaker: "SPEAKER_05"
+    confidence: medium
+    reason: |
+      Единственная короткая реплика, скорее всего ошибка распознавания.
+      Требуется voice comparison для точного определения.
+
+# Задачи для дальнейшей работы
+tasks:
+  - type: add_to_people_yaml
+    priority: high
+    description: |
+      Добавить двух новых гостей в people.yaml:
+      1. Дмитрий - молодой разработчик, первое появление
+      2. Руслан - был 2 раза ранее на подкасте
+    note: "Требуется найти фамилии/никнеймы для полной идентификации"
+
+  - type: find_previous_episodes
+    priority: medium
+    description: |
+      Найти 2 предыдущих выпуска с участием Руслана
+      для установления его полного имени и person_id
+
+  - type: voice_comparison
+    priority: low
+    speaker: "SPEAKER_05"
+    description: |
+      Определить, кому принадлежит единственная реплика SPEAKER_05
+    reference_segment:
+      stime: 1816.61
+      etime: 1819.86
+      text: "Потому что никто еще в жизни не попользовался"

--- a/validation/episodes/0300-0399/0398.yaml
+++ b/validation/episodes/0300-0399/0398.yaml
@@ -1,0 +1,185 @@
+episode: 398
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  guests_identified: [EldarMurtazin, Marin_k_a]
+  total_duration_sec: 7946  # примерно 2ч 12мин (судя по статистике)
+
+# Представление участников в начале эпизода:
+# - Umputun приветствует "Ксюша" в 15-17с (обращение к SPEAKER_01)
+# - Bobuk появляется с 56с
+# - Marin_k_a (Маруся) - обсуждается 300-й выпуск (35с)
+# - EldarMurtazin представлен как "Эльдар" (91-100с), шутка про "Ильдар.Мортазин" в скайпе
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 806
+    replies_count: 275
+    first_reply_at: 14.8
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        В начале эпизода (15-17с):
+        - Umputun: "Уже была ты, Ксюша, с нами, когда мы праздновали 300-й?"
+        - SPEAKER_01: "Конечно. Ну, нет. Наверное, еще нет."
+        Обращение по имени "Ксюша" однозначно указывает на Ksenks.
+        Активное участие на протяжении всего выпуска, осмысленные реплики.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "EldarMurtazin"
+    total_duration_sec: 2402
+    replies_count: 519
+    first_reply_at: 100.4
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "eldar_murtazin"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        В начале эпизода (91-104с):
+        - Umputun: "Эльдар. Ты же дважды Эльдар Советского Союза."
+        - EldarMurtazin: "Слушай, у меня в скайпе написано Ильдар.Мортазин."
+        Гость уже корректно идентифицирован в транскрипте.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 651
+    replies_count: 102
+    first_reply_at: 35.5
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: high
+      evidence: |
+        В начале эпизода (35с) при обсуждении 300-го выпуска:
+        - Umputun: "подарки, я помню, Маруся, настоящая... она подарки раздавала тогда"
+        - Marin_k_a: "Ну да, по-моему, она как раз тогда и объявила, что это ее последний выпуск"
+        Уже корректно идентифицирована в транскрипте.
+
+      possible_matches: []
+
+      voice_task:
+        needed: false
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 4
+    replies_count: 3
+    first_reply_at: 1654.7
+    pattern: consecutive
+
+    analysis:
+      is_error: false  # Скорее всего ошибка распознавания, но не артефакт
+      error_reason: null
+
+      identified_as: null  # Требует voice verification
+      identification_method: null
+      confidence: null
+      evidence: |
+        Три короткие последовательные реплики (1654-1658с):
+        - "В смысле?"
+        - "Да вы что, нет?"
+        - "Блин, да я серьезно сейчас."
+        Эмоциональные реакции в контексте обсуждения алгоритмов Tinder.
+        По характеру реплик похоже на женский голос (Ksenks или Marin_k_a).
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "Эмоциональная реакция, женский голос, активное участие в выпуске"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Женский голос, присутствует в выпуске"
+
+      voice_task:
+        needed: true
+        reason: "Короткий сегмент, требуется сравнение с голосами Ksenks и Marin_k_a"
+        reference_segment:
+          stime: 1654.69
+          etime: 1658.82
+          text: "В смысле? Да вы что, нет? Блин, да я серьезно сейчас."
+
+  - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    total_duration_sec: 3
+    replies_count: 1
+    first_reply_at: 1563.0
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: "Ошибочная атрибуция - одиночная реплика между двумя репликами Marin_k_a"
+
+      identified_as: "marin_k_a"
+      identification_method: "context"
+      confidence: medium
+      evidence: |
+        Одна реплика (1563с): "Ну, в общем, это привлекает внимание."
+        Контекст:
+        - Marin_k_a (1547-1563с): обсуждает iPhone в магазинах
+        - SPEAKER_MISATTRIBUTED_LAVALE (1563-1565с): "Ну, в общем, это привлекает внимание"
+        - Marin_k_a (1565-1576с): продолжает тему
+        Логическое продолжение речи Марины. Lavale не присутствует в этом эпизоде.
+
+      possible_matches:
+        - person_id: "marin_k_a"
+          confidence: 0.8
+          reason: "Продолжение её речи, нет разрыва темы"
+        - person_id: "ksenks"
+          confidence: 0.15
+          reason: "Тоже присутствует в выпуске"
+
+      voice_task:
+        needed: false
+        reason: "Очевидная ошибка атрибуции, скорее всего Marin_k_a"
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "SPEAKER_01"
+      issue: "Должен быть переименован в Ksenks - однозначное обращение по имени"
+    - speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+      issue: "Ошибочная атрибуция, Lavale не участвует в этом выпуске"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 398
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: "Umputun обращается 'Ксюша' в 15-17с, однозначная идентификация"
+
+  - type: rename
+    episode: 398
+    from_speaker: "SPEAKER_MISATTRIBUTED_LAVALE"
+    to_speaker: "Marin_k_a"
+    confidence: medium
+    reason: "Одиночная реплика между репликами Marin_k_a, логическое продолжение её речи"

--- a/validation/episodes/0300-0399/0399.yaml
+++ b/validation/episodes/0300-0399/0399.yaml
@@ -1,0 +1,210 @@
+episode: 399
+status: needs_review
+analyzed_at: "2026-01-25"
+
+# Статистика по всем спикерам
+speakers_summary:
+  hosts_present: [Umputun, Bobuk]
+  # Gray отсутствует - это явно указано в начале выпуска: "Состав у нас все, кроме Грея"
+  # Также участвуют: Marin_k_a (Марина, бывшая ведущая) и Ksenks (под SPEAKER_01)
+  total_duration_sec: 7883
+
+# Детальный анализ неизвестных спикеров
+unknown_speakers:
+  - speaker: "SPEAKER_01"
+    total_duration_sec: 317
+    replies_count: 127
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация: это Ksenks (Ксюша)
+      # Доказательства:
+      # 1. В начале выпуска Umputun представляет состав: "Бобук... и Ксюша" (50-55s)
+      # 2. Ksenks НЕ появляется ни разу как author в этом выпуске
+      # 3. Umputun неоднократно обращается к "Ксюше", и отвечает SPEAKER_01
+      #    Пример: 4765s "Ксюша, ты читала статью..." -> 4771s SPEAKER_01: "Ну вот я сейчас в процессе..."
+      # 4. Marin_k_a и SPEAKER_01 - разные люди, чередуются в диалогах
+      identified_as: "ksenks"
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Umputun представляет Ksenks в начале (50s): "И есть Ксюша..."
+        Обращения к Ксюше с ответами SPEAKER_01:
+        - 4765s: "Ксюша, ты читала статью..." -> 4771s SPEAKER_01: "Ну вот я сейчас в процессе..."
+        - 4817s: Bobuk: "Ксюша?" -> 4822s SPEAKER_01: "Почему?"
+        В эпизоде нет ни одной реплики от автора "Ksenks", но есть 127 реплик SPEAKER_01.
+
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_02"
+    total_duration_sec: 679
+    replies_count: 165
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Идентификация: гость "Алексей"
+      # Это слушатель из чата, который раньше защищал Ruby
+      identified_as: null  # Неизвестный гость, нет в people.yaml
+      identification_method: "introduction"
+      confidence: high
+      evidence: |
+        Umputun зовёт гостя по имени (4743s): "Алексей?"
+        Гость отвечает (4749s): "Да, я уже второй раз Ruby защищал у вас."
+        Контекст: дискуссия о переходе TJ Holowaychuk с Node.js на Go.
+        Гость активно участвует в обсуждении Go vs Node.js/Ruby.
+
+      possible_matches:
+        - person_id: "new_guest_alexey_ruby"
+          confidence: 0.9
+          reason: "Представился как Алексей, говорит что второй раз защищал Ruby"
+
+      voice_task:
+        needed: true
+        reference_segment:
+          stime: 5022.75
+          etime: 5046.42
+          text: "Да, кстати, ещё. Ну, он очень интересный чувак, потому что у него нет формального образования. Он всё освоил сам. И вот на это все обращают внимание — как это он умудрился без формального образования."
+
+  - speaker: "Marin_k_a"
+    total_duration_sec: 597
+    replies_count: 112
+    pattern: consecutive
+
+    analysis:
+      is_error: false
+      error_reason: null
+
+      # Это Марина - бывшая ведущая, известный участник
+      identified_as: "marin_k_a"
+      identification_method: "known_participant"
+      confidence: high
+      evidence: "Marin_k_a - известный участник из people.yaml (бывшая ведущая Марина)"
+
+      possible_matches: []
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_05"
+    total_duration_sec: 5
+    replies_count: 4
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Очень короткие реплики (всего 5 сек на 4 реплики), разбросаны по эпизоду:
+        - 1586s: "Меня не угнетает." (1 сек) - в контексте слов Bobuk
+        - 2830s: "Нет." (0.2 сек) - одно слово
+        - 4912s: "Хочешь, я тебе расскажу?" (2.5 сек) - после вопроса к Ксюше
+        - 4940s: "Наоборот." (1 сек) - одно слово
+        Это ошибки распознавания, скорее всего перебивки других спикеров.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "ksenks"
+          confidence: 0.6
+          reason: "Реплика 4912s идёт сразу после вопроса к Ксюше - может быть её ответ"
+        - person_id: "marin_k_a"
+          confidence: 0.3
+          reason: "Marin_k_a также активна в этом эпизоде"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+  - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    total_duration_sec: 1
+    replies_count: 1
+    pattern: scattered
+
+    analysis:
+      is_error: true
+      error_reason: |
+        Одна короткая реплика (1 сек) в 3834s: "Мне понадобилось поднять Private Registry."
+        Контекст: Umputun рассказывает о Docker Registry, и эта реплика - часть его рассказа.
+        Маркер MISATTRIBUTED указывает, что это уже была отмечена как ошибочная атрибуция.
+        Скорее всего это реплика Umputun, ошибочно вырезанная как отдельный спикер.
+
+      identified_as: null
+      identification_method: null
+      confidence: null
+      evidence: null
+
+      possible_matches:
+        - person_id: "umputun"
+          confidence: 0.8
+          reason: "Реплика в контексте монолога Umputun о Docker Registry"
+
+      voice_task:
+        needed: false
+        reference_segment: null
+
+# Проверка консистентности
+consistency_check:
+  all_speakers_introduced: true
+  issues:
+    - speaker: "SPEAKER_01"
+      issue: "Должен быть переименован в Ksenks - это явно Ксюша на основании контекста"
+    - speaker: "SPEAKER_02"
+      issue: "Гость 'Алексей' не добавлен в people.yaml - нужно создать запись"
+    - speaker: "SPEAKER_05"
+      issue: "Ошибки распознавания - нужно проверить и переатрибутировать"
+    - speaker: "SPEAKER_MISATTRIBUTED_PETR"
+      issue: "Скорее всего реплика Umputun - требует проверки"
+
+# Предлагаемые правила очистки
+suggested_rules:
+  - type: rename
+    episode: 399
+    from_speaker: "SPEAKER_01"
+    to_speaker: "Ksenks"
+    confidence: high
+    reason: |
+      Umputun представляет Ksenks в начале выпуска.
+      Все обращения к "Ксюше" получают ответы от SPEAKER_01.
+      В эпизоде нет реплик от автора "Ksenks", но есть 127 реплик SPEAKER_01.
+
+  - type: rename
+    episode: 399
+    from_speaker: "SPEAKER_02"
+    to_speaker: "GuestAlexey399"
+    confidence: high
+    reason: |
+      Umputun зовёт гостя "Алексей" в 4743s.
+      Гость представляется: "второй раз Ruby защищал у вас".
+      Нужно также добавить в people.yaml.
+
+  - type: rename
+    episode: 399
+    from_speaker: "SPEAKER_MISATTRIBUTED_PETR"
+    to_speaker: "Umputun"
+    confidence: medium
+    reason: |
+      Реплика в контексте монолога Umputun о Docker.
+      Требует дополнительной проверки по голосу.
+
+# Примечания
+notes: |
+  Эпизод 399 от 5 июля 2014 года.
+  Состав: Umputun, Bobuk, Ksenks (как SPEAKER_01), Marin_k_a.
+  Gray отсутствует (явно указано в начале).
+
+  Гость: Алексей (SPEAKER_02) - слушатель из чата, защищал Ruby ранее.
+  Появляется с 4750s, активно участвует в обсуждении Go vs Node.js.
+
+  SPEAKER_05 - ошибки распознавания (4 короткие реплики).
+  SPEAKER_MISATTRIBUTED_PETR - уже помечена как ошибка, 1 реплика.


### PR DESCRIPTION
## Summary
- Провалидированы спикеры для 100 эпизодов (300-399)
- Каждый YAML-файл содержит анализ ведущих и гостей эпизода
- Использован Claude Code для автоматического анализа

## Files
- 100 YAML файлов в `validation/episodes/0300-0399/`

Closes #3